### PR TITLE
TRUS-1883: Remove aria-hidden + visually hidden elements 

### DIFF
--- a/app/views/components/form_hint.scala.html
+++ b/app/views/components/form_hint.scala.html
@@ -22,17 +22,11 @@ readerHint: Option[String] = None,
 link: Option[Link] = None
 )(implicit messages: Messages)
 
+
 @if(hint.nonEmpty) {
-  <span id="form-hint" class="form-hint form-field" @if(readerHint.nonEmpty){aria-hidden="true"}>@hint
+<span id="form-hint" class="form-hint form-field" @if(readerHint.nonEmpty){aria-label="@readerHint"}>@hint
   @link.map { l =>
     <a id="link" href="@l.url" target="_blank">@l.text</a>
   }
   </span>
-  @if(readerHint.nonEmpty){
-    <span class="visuallyhidden" aria-hidden="false">@readerHint
-    @link.map { l =>
-      <a id="hidden-link" href="@l.url" target="_blank">@l.text</a>
-    }
-    </span>
-  }
 }

--- a/app/views/components/input_text.scala.html
+++ b/app/views/components/input_text.scala.html
@@ -43,8 +43,7 @@
     @if(optionalHtmlContent.nonEmpty){@optionalHtmlContent}
     @if(hint.nonEmpty){
         <div id="@{field.id}_hint">
-            <span class="form-hint form-field" @if(readerHint.nonEmpty){aria-hidden="true"}>@hint</span>
-            @if(readerHint.nonEmpty){<span class="visuallyhidden">@readerHint</span>}
+            <span class="form-hint form-field" @if(readerHint.nonEmpty){aria-label="@readerHint"}>@hint</span>
         </div>
     }
     @field.errors.map { error =>


### PR DESCRIPTION
to provide alternate aria-label. Uses aria-label attribute now. Corrects accessibility error.