### PR TITLE
Styling print page

### DIFF
--- a/app/assets/stylesheets/maintainatrustfrontend-app.scss
+++ b/app/assets/stylesheets/maintainatrustfrontend-app.scss
@@ -18,6 +18,7 @@
 @import 'partials/task-list';
 @import 'partials/_modal';
 @import 'patterns/tag';
+@import 'patterns/check-your-answers';
 
 .push-text-top--3 {
   padding-top: govuk-spacing(3);

--- a/app/assets/stylesheets/patterns/_check-your-answers.scss
+++ b/app/assets/stylesheets/patterns/_check-your-answers.scss
@@ -1,0 +1,24 @@
+.cya-question, .cya-answer, .cya-change {
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+}
+
+.govuk-check-your-answers.cya-questions-long .cya-question {
+    width: 100%;
+
+    @include media(desktop) {
+        width: 60%;
+    }
+}
+
+.govuk-check-your-answers.cya-questions-long .cya-answer {
+    width: 100%;
+
+    @include media(desktop) {
+        width: 40%;
+    }
+}
+
+.govuk-check-your-answers {
+    table-layout: fixed;
+}

--- a/app/views/PlaybackAnswersView.scala.html
+++ b/app/views/PlaybackAnswersView.scala.html
@@ -39,7 +39,7 @@
     @for(section <- entities){
         @{
             section match {
-                case a: AnswerSection => components.answer_section(a)
+                case a: AnswerSection => components.summary_answer_section(a)
                 case r: RepeaterAnswerSection => components.repeater_answer_section(r)
             }
         }
@@ -51,7 +51,7 @@
     @for(section <- trustDetails){
         @{
             section match {
-                case a: AnswerSection => components.answer_section(a)
+                case a: AnswerSection => components.summary_answer_section(a)
                 case r: RepeaterAnswerSection => components.repeater_answer_section(r)
             }
         }

--- a/app/views/components/summary_answer_row_without_actions.scala.html
+++ b/app/views/components/summary_answer_row_without_actions.scala.html
@@ -1,0 +1,24 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import viewmodels.AnswerRow
+
+@(row: AnswerRow)(implicit messages: Messages)
+
+<li>
+    <div class="cya-question">@messages(row.label, row.labelArg)</div>
+    <div class="cya-answer">@row.answer</div>
+</li>

--- a/app/views/components/summary_answer_section.scala.html
+++ b/app/views/components/summary_answer_section.scala.html
@@ -1,0 +1,36 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import viewmodels.AnswerSection
+@import views.html._
+
+@(answerSection: AnswerSection)(implicit messages: Messages)
+
+@if(answerSection.sectionKey.isDefined){
+<h2 class="heading-large">@messages(answerSection.sectionKey.get)</h2>
+}
+
+@if(answerSection.headingKey.isDefined){
+<h3 class="heading-medium">@messages(answerSection.headingKey.get)</h3>
+}
+
+@if(answerSection.rows) {
+<ul role="list" class="govuk-check-your-answers cya-questions-long section">
+    @for(row <- answerSection.rows){
+    @components.summary_answer_row_without_actions(row)
+    }
+</ul>
+}

--- a/app/views/declaration/PlaybackDeclaredAnswersView.scala.html
+++ b/app/views/declaration/PlaybackDeclaredAnswersView.scala.html
@@ -61,7 +61,7 @@
     @for(section <- entities){
         @{
             section match {
-                case a: AnswerSection => components.answer_section(a)
+                case a: AnswerSection => components.summary_answer_section(a)
                 case r: RepeaterAnswerSection => components.repeater_answer_section(r)
             }
         }
@@ -73,7 +73,7 @@
     @for(section <- trustDetails){
         @{
             section match {
-                case a: AnswerSection => components.answer_section(a)
+                case a: AnswerSection => components.summary_answer_section(a)
                 case r: RepeaterAnswerSection => components.repeater_answer_section(r)
             }
         }


### PR DESCRIPTION
Fixing styling problems on print overview pages. This now correctly wraps the words on the page, and ensures each column is equal size, therefore, all the content sits flush left.

<img width="310" alt="Screenshot 2020-03-23 at 17 05 43" src="https://user-images.githubusercontent.com/2979782/77344165-ac994000-6d2a-11ea-8a72-c055411cc00e.png">
