### PR TITLE
TRUS-2822 Starting a new session each time a UTR is given

### DIFF
--- a/app/controllers/UTRController.scala
+++ b/app/controllers/UTRController.scala
@@ -55,10 +55,10 @@ class UTRController @Inject()(
         utr => {
           for {
             _ <- playbackRepository.resetCache(request.user.internalId)
-            newSessionWithAnswers <- Future.fromTry {
+            newSessionWithUtr <- Future.fromTry {
               UserAnswers.startNewSession(request.user.internalId).set(UTRPage, utr)
             }
-            _ <- playbackRepository.set(newSessionWithAnswers)
+            _ <- playbackRepository.set(newSessionWithUtr)
           } yield Redirect(controllers.routes.TrustStatusController.status())
         }
       )

--- a/app/models/UserAnswers.scala
+++ b/app/models/UserAnswers.scala
@@ -85,6 +85,8 @@ final case class UserAnswers(
 
 object UserAnswers {
 
+  def startNewSession(internalId: String) : UserAnswers = UserAnswers(internalId)
+
   implicit lazy val reads: Reads[UserAnswers] = {
 
     import play.api.libs.functional.syntax._

--- a/test/controllers/UTRControllerSpec.scala
+++ b/test/controllers/UTRControllerSpec.scala
@@ -93,26 +93,6 @@ class UTRControllerSpec extends SpecBase {
       application.stop()
     }
 
-    "populate the view correctly on a GET when the question has previously been answered" in {
-
-      val userAnswers = emptyUserAnswers.set(UTRPage, "0987654321").success.value
-
-      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
-
-      val request = FakeRequest(GET, trustUTRRoute)
-
-      val view = application.injector.instanceOf[UTRView]
-
-      val result = route(application, request).value
-
-      status(result) mustEqual OK
-
-      contentAsString(result) mustEqual
-        view(form.fill("0987654321"), onSubmit)(fakeRequest, messages).toString
-
-      application.stop()
-    }
-
     "redirect to trust status on a POST" in {
 
       val utr = "0987654321"


### PR DESCRIPTION
This fixes a bug in where if the user already had a session as an Agent, went back to the utr page, entered a different UTR, then the answers in mongo were merged with the extractor `.combine` call with the newly fetched data.
This explicitly starts a new session each time a UTR is provided to ensure user answers has no carry over in the request.