### PR TITLE
Taxability determined by a combination of the identifier type and the…

### DIFF
--- a/app/connectors/TrustConnector.scala
+++ b/app/connectors/TrustConnector.scala
@@ -31,15 +31,15 @@ class TrustConnector @Inject()(http: HttpClient, config: FrontendAppConfig) {
 
   private lazy val baseUrl: String = s"${config.trustsUrl}/trusts"
 
-  def getTrustDetails(identifier: String)
-                     (implicit hc: HeaderCarrier, ex: ExecutionContext): Future[TrustDetails] = {
-    val url: String = s"$baseUrl/$identifier/trust-details"
+  def getUntransformedTrustDetails(identifier: String)
+                                  (implicit hc: HeaderCarrier, ex: ExecutionContext): Future[TrustDetails] = {
+    val url: String = s"$baseUrl/trust-details/$identifier/untransformed"
     http.GET[TrustDetails](url)
   }
 
   def getStartDate(identifier: String)
                   (implicit hc: HeaderCarrier, ex: ExecutionContext): Future[LocalDate] = {
-    getTrustDetails(identifier) map { trustDetails =>
+    getUntransformedTrustDetails(identifier) map { trustDetails =>
       trustDetails.startDate
     }
   }
@@ -102,12 +102,6 @@ class TrustConnector @Inject()(http: HttpClient, config: FrontendAppConfig) {
                      (implicit hc: HeaderCarrier, ex: ExecutionContext): Future[HttpResponse] = {
     val url: String = s"$baseUrl/trust-details/$identifier/taxable"
     http.PUT[Boolean, HttpResponse](url, value)
-  }
-
-  def isTrust5mld(identifier: String)
-                 (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Boolean] = {
-    val url: String = s"$baseUrl/$identifier/is-trust-5mld"
-    http.GET[Boolean](url)
   }
 
 }

--- a/app/connectors/TrustConnector.scala
+++ b/app/connectors/TrustConnector.scala
@@ -93,4 +93,10 @@ class TrustConnector @Inject()(http: HttpClient, config: FrontendAppConfig) {
     http.PUT[Boolean, HttpResponse](url, value)
   }
 
+  def isTrust5mld(identifier: String)
+                 (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Boolean] = {
+    val url: String = s"${config.trustsUrl}/trusts/$identifier/is-trust-5mld"
+    http.GET[Boolean](url)
+  }
+
 }

--- a/app/connectors/TrustConnector.scala
+++ b/app/connectors/TrustConnector.scala
@@ -31,71 +31,82 @@ class TrustConnector @Inject()(http: HttpClient, config: FrontendAppConfig) {
 
   private lazy val baseUrl: String = s"${config.trustsUrl}/trusts"
 
-  def getTrustDetails(identifier: String)(implicit hc: HeaderCarrier, ex: ExecutionContext): Future[TrustDetails] = {
+  def getTrustDetails(identifier: String)
+                     (implicit hc: HeaderCarrier, ex: ExecutionContext): Future[TrustDetails] = {
     val url: String = s"$baseUrl/$identifier/trust-details"
     http.GET[TrustDetails](url)
   }
 
-  def getStartDate(identifier: String)(implicit hc: HeaderCarrier, ex: ExecutionContext): Future[LocalDate] = {
-    for {
-      details <- getTrustDetails(identifier)
-      date = LocalDate.parse(details.startDate)
-    } yield date
+  def getStartDate(identifier: String)
+                  (implicit hc: HeaderCarrier, ex: ExecutionContext): Future[LocalDate] = {
+    getTrustDetails(identifier) map { trustDetails =>
+      trustDetails.startDate
+    }
   }
 
-  def playback(identifier: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[TrustsResponse] = {
+  def playback(identifier: String)
+              (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[TrustsResponse] = {
     val url: String = s"$baseUrl/$identifier/transformed"
     http.GET[TrustsResponse](url)(TrustsStatusReads.httpReads, hc, ec)
   }
 
-  def playbackFromEtmp(identifier: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[TrustsResponse] = {
+  def playbackFromEtmp(identifier: String)
+                      (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[TrustsResponse] = {
     val url: String = s"$baseUrl/$identifier/refresh"
     http.GET[TrustsResponse](url)(TrustsStatusReads.httpReads, hc, ec)
   }
 
-  def getDoProtectorsAlreadyExist(identifier: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[JsBoolean] = {
+  def getDoProtectorsAlreadyExist(identifier: String)
+                                 (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[JsBoolean] = {
     val url: String = s"$baseUrl/$identifier/transformed/protectors-already-exist"
     http.GET[JsBoolean](url)
   }
 
-  def getDoOtherIndividualsAlreadyExist(identifier: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[JsBoolean] = {
+  def getDoOtherIndividualsAlreadyExist(identifier: String)
+                                       (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[JsBoolean] = {
     val url: String = s"$baseUrl/$identifier/transformed/other-individuals-already-exist"
     http.GET[JsBoolean](url)
   }
 
-  def getDoNonEeaCompaniesAlreadyExist(identifier: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[JsBoolean] = {
+  def getDoNonEeaCompaniesAlreadyExist(identifier: String)
+                                      (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[JsBoolean] = {
     val url: String = s"$baseUrl/$identifier/transformed/non-eea-companies-already-exist"
     http.GET[JsBoolean](url)
   }
 
-  def declare(identifier: String, payload: JsValue)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[DeclarationResponse] = {
+  def declare(identifier: String, payload: JsValue)
+             (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[DeclarationResponse] = {
     val url: String = s"$baseUrl/declare/$identifier"
     http.POST[JsValue, DeclarationResponse](url, payload)(implicitly[Writes[JsValue]], DeclarationResponse.httpReads, hc, ec)
   }
 
-  def setTaxableMigrationFlag(identifier: String, value: Boolean)(implicit hc: HeaderCarrier, ex: ExecutionContext): Future[HttpResponse] = {
+  def setTaxableMigrationFlag(identifier: String, value: Boolean)
+                             (implicit hc: HeaderCarrier, ex: ExecutionContext): Future[HttpResponse] = {
     val url: String = s"$baseUrl/$identifier/taxable-migration/migrating-to-taxable"
     http.POST[Boolean, HttpResponse](url, value)
   }
 
-  def removeTransforms(identifier: String)(implicit hc: HeaderCarrier, ex: ExecutionContext): Future[HttpResponse] = {
+  def removeTransforms(identifier: String)
+                      (implicit hc: HeaderCarrier, ex: ExecutionContext): Future[HttpResponse] = {
     val url: String = s"$baseUrl/$identifier/transforms"
     http.DELETE[HttpResponse](url)
   }
 
-  def setExpressTrust(identifier: String, value: Boolean)(implicit hc: HeaderCarrier, ex: ExecutionContext): Future[HttpResponse] = {
+  def setExpressTrust(identifier: String, value: Boolean)
+                     (implicit hc: HeaderCarrier, ex: ExecutionContext): Future[HttpResponse] = {
     val url: String = s"$baseUrl/trust-details/$identifier/express"
     http.PUT[Boolean, HttpResponse](url, value)
   }
 
-  def setTaxableTrust(identifier: String, value: Boolean)(implicit hc: HeaderCarrier, ex: ExecutionContext): Future[HttpResponse] = {
+  def setTaxableTrust(identifier: String, value: Boolean)
+                     (implicit hc: HeaderCarrier, ex: ExecutionContext): Future[HttpResponse] = {
     val url: String = s"$baseUrl/trust-details/$identifier/taxable"
     http.PUT[Boolean, HttpResponse](url, value)
   }
 
   def isTrust5mld(identifier: String)
                  (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Boolean] = {
-    val url: String = s"${config.trustsUrl}/trusts/$identifier/is-trust-5mld"
+    val url: String = s"$baseUrl/$identifier/is-trust-5mld"
     http.GET[Boolean](url)
   }
 

--- a/app/connectors/TrustConnector.scala
+++ b/app/connectors/TrustConnector.scala
@@ -18,8 +18,8 @@ package connectors
 
 import config.FrontendAppConfig
 import models.TrustDetails
-import models.http.{DeclarationResponse, TrustsResponse, TrustsStatusReads}
-import play.api.libs.json.{JsBoolean, JsValue, Writes}
+import models.http.{DeclarationForApi, DeclarationResponse, TrustsResponse}
+import play.api.libs.json.JsBoolean
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
 
@@ -47,13 +47,13 @@ class TrustConnector @Inject()(http: HttpClient, config: FrontendAppConfig) {
   def playback(identifier: String)
               (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[TrustsResponse] = {
     val url: String = s"$baseUrl/$identifier/transformed"
-    http.GET[TrustsResponse](url)(TrustsStatusReads.httpReads, hc, ec)
+    http.GET[TrustsResponse](url)
   }
 
   def playbackFromEtmp(identifier: String)
                       (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[TrustsResponse] = {
     val url: String = s"$baseUrl/$identifier/refresh"
-    http.GET[TrustsResponse](url)(TrustsStatusReads.httpReads, hc, ec)
+    http.GET[TrustsResponse](url)
   }
 
   def getDoProtectorsAlreadyExist(identifier: String)
@@ -74,10 +74,10 @@ class TrustConnector @Inject()(http: HttpClient, config: FrontendAppConfig) {
     http.GET[JsBoolean](url)
   }
 
-  def declare(identifier: String, payload: JsValue)
+  def declare(identifier: String, payload: DeclarationForApi)
              (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[DeclarationResponse] = {
     val url: String = s"$baseUrl/declare/$identifier"
-    http.POST[JsValue, DeclarationResponse](url, payload)(implicitly[Writes[JsValue]], DeclarationResponse.httpReads, hc, ec)
+    http.POST[DeclarationForApi, DeclarationResponse](url, payload)
   }
 
   def setTaxableMigrationFlag(identifier: String, value: Boolean)

--- a/app/controllers/IndexController.scala
+++ b/app/controllers/IndexController.scala
@@ -63,11 +63,7 @@ class IndexController @Inject()(
     val utr = getIdentifierFromEnrolment("HMRC-TERS-ORG", "SAUTR")
     val urn = getIdentifierFromEnrolment("HMRC-TERSNT-ORG", "URN")
 
-    val identifier = (utr, urn) match {
-      case (Some(_), None) => utr
-      case (None, Some(_)) => urn
-      case _ => None
-    }
+    val identifier: Option[String] = utr.orElse(urn).orElse(None)
 
     identifier match {
       case Some(value) =>

--- a/app/controllers/IndexController.scala
+++ b/app/controllers/IndexController.scala
@@ -69,8 +69,14 @@ class IndexController @Inject()(
       case Some(value) =>
         for {
           is5mldEnabled <- featureFlagService.is5mldEnabled()
-          isUnderlyingData5mld <- trustsConnector.isTrust5mld(value)
-          result <- uaSetupService.setupAndRedirectToStatus(value, request.user.internalId, is5mldEnabled, isUnderlyingData5mld)
+          trustDetails <- trustsConnector.getUntransformedTrustDetails(value)
+          result <- uaSetupService.setupAndRedirectToStatus(
+            identifier = value,
+            internalId = request.user.internalId,
+            is5mldEnabled = is5mldEnabled,
+            isUnderlyingData5mld = trustDetails.is5mld,
+            isUnderlyingDataTaxable = trustDetails.isTaxable
+          )
         } yield result
       case None =>
         logger.info(s"[Session ID: ${Session.id(hc)}]" +

--- a/app/controllers/IndexController.scala
+++ b/app/controllers/IndexController.scala
@@ -17,6 +17,7 @@
 package controllers
 
 import com.google.inject.{Inject, Singleton}
+import connectors.TrustConnector
 import controllers.actions.Actions
 import models.requests.IdentifierRequest
 import play.api.Logging
@@ -33,7 +34,8 @@ class IndexController @Inject()(
                                  val controllerComponents: MessagesControllerComponents,
                                  actions: Actions,
                                  uaSetupService: UserAnswersSetupService,
-                                 featureFlagService: FeatureFlagService
+                                 featureFlagService: FeatureFlagService,
+                                 trustsConnector: TrustConnector
                                )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport with Logging {
 
   def onPageLoad(): Action[AnyContent] = actions.auth.async {
@@ -52,24 +54,34 @@ class IndexController @Inject()(
   }
 
   private def initialise(redirect: Result)(implicit request: IdentifierRequest[_]): Future[Result] = {
-    def identifier(enrolmentKey: String, identifierKey: String): Option[String] = request.user.enrolments.enrolments
+
+    def getIdentifierFromEnrolment(enrolmentKey: String, identifierKey: String): Option[String] = request.user.enrolments.enrolments
       .find(_.key equals enrolmentKey)
       .flatMap(_.identifiers.find(_.key equals identifierKey))
       .map(_.value)
 
-    val utr = identifier("HMRC-TERS-ORG", "SAUTR")
-    val urn = identifier("HMRC-TERSNT-ORG", "URN")
+    val utr = getIdentifierFromEnrolment("HMRC-TERS-ORG", "SAUTR")
+    val urn = getIdentifierFromEnrolment("HMRC-TERSNT-ORG", "URN")
 
-    featureFlagService.is5mldEnabled().flatMap {
-      is5mldEnabled =>
-        (utr, urn) match {
-          case (Some(utr), _) => uaSetupService.setupAndRedirectToStatus(utr, request.user.internalId, is5mldEnabled, isTaxable = true)
-          case (_, Some(urn)) => uaSetupService.setupAndRedirectToStatus(urn, request.user.internalId, is5mldEnabled, isTaxable = false)
-          case _ =>
-            logger.info(s"[Session ID: ${Session.id(hc)}]" +
-              s" user is not enrolled, starting maintain journey, redirect to ask for identifier")
-            Future.successful(redirect)
+    val identifier = (utr, urn) match {
+      case (Some(_), None) => utr
+      case (None, Some(_)) => urn
+      case _ => None
+    }
+
+    identifier match {
+      case Some(value) =>
+        for {
+          is5mldEnabled <- featureFlagService.is5mldEnabled()
+          isUnderlyingData5mld <- trustsConnector.isTrust5mld(value)
+          result <- uaSetupService.setupAndRedirectToStatus(value, request.user.internalId, is5mldEnabled, isUnderlyingData5mld)
+        } yield {
+          result
         }
+      case None =>
+        logger.info(s"[Session ID: ${Session.id(hc)}]" +
+          s" user is not enrolled, starting maintain journey, redirect to ask for identifier")
+        Future.successful(redirect)
     }
   }
 }

--- a/app/controllers/IndexController.scala
+++ b/app/controllers/IndexController.scala
@@ -75,9 +75,7 @@ class IndexController @Inject()(
           is5mldEnabled <- featureFlagService.is5mldEnabled()
           isUnderlyingData5mld <- trustsConnector.isTrust5mld(value)
           result <- uaSetupService.setupAndRedirectToStatus(value, request.user.internalId, is5mldEnabled, isUnderlyingData5mld)
-        } yield {
-          result
-        }
+        } yield result
       case None =>
         logger.info(s"[Session ID: ${Session.id(hc)}]" +
           s" user is not enrolled, starting maintain journey, redirect to ask for identifier")

--- a/app/controllers/URNController.scala
+++ b/app/controllers/URNController.scala
@@ -51,7 +51,7 @@ class URNController @Inject()(
         (formWithErrors: Form[_]) =>
           Future.successful(BadRequest(view(formWithErrors, routes.URNController.onSubmit()))),
         urn => {
-          uaSetupService.setupAndRedirectToStatus(urn, request.user.internalId, is5mldEnabled = true, isTaxable = false)
+          uaSetupService.setupAndRedirectToStatus(urn, request.user.internalId, is5mldEnabled = true, isUnderlyingData5mld = true)
         }
       )
   }

--- a/app/controllers/URNController.scala
+++ b/app/controllers/URNController.scala
@@ -51,7 +51,13 @@ class URNController @Inject()(
         (formWithErrors: Form[_]) =>
           Future.successful(BadRequest(view(formWithErrors, routes.URNController.onSubmit()))),
         urn => {
-          uaSetupService.setupAndRedirectToStatus(urn, request.user.internalId, is5mldEnabled = true, isUnderlyingData5mld = true)
+          uaSetupService.setupAndRedirectToStatus(
+            identifier = urn,
+            internalId = request.user.internalId,
+            is5mldEnabled = true,
+            isUnderlyingData5mld = true,
+            isUnderlyingDataTaxable = false
+          )
         }
       )
   }

--- a/app/controllers/UTRController.scala
+++ b/app/controllers/UTRController.scala
@@ -56,8 +56,14 @@ class UTRController @Inject()(
         utr => {
           for {
             is5mldEnabled <- featureFlagService.is5mldEnabled()
-            isUnderlyingData5mld <- trustsConnector.isTrust5mld(utr)
-            result <- uaSetupService.setupAndRedirectToStatus(utr, request.user.internalId, is5mldEnabled, isUnderlyingData5mld)
+            trustDetails <- trustsConnector.getUntransformedTrustDetails(utr)
+            result <- uaSetupService.setupAndRedirectToStatus(
+              identifier = utr,
+              internalId = request.user.internalId,
+              is5mldEnabled = is5mldEnabled,
+              isUnderlyingData5mld = trustDetails.is5mld,
+              isUnderlyingDataTaxable = trustDetails.isTaxable
+            )
           } yield result
         }
       )

--- a/app/controllers/WhatIsNextController.scala
+++ b/app/controllers/WhatIsNextController.scala
@@ -96,6 +96,7 @@ class WhatIsNextController @Inject()(
         case NoLongerTaxable =>
           controllers.routes.NoTaxLiabilityInfoController.onPageLoad()
         case NeedsToPayTax =>
+          // TODO - set taxable trust transform
           controllers.routes.FeatureNotAvailableController.onPageLoad()
         case GeneratePdf =>
           controllers.routes.ObligedEntityPdfController.getPdf(request.userAnswers.identifier)

--- a/app/mapping/UserAnswersExtractor.scala
+++ b/app/mapping/UserAnswersExtractor.scala
@@ -57,9 +57,9 @@ class UserAnswersExtractorImpl @Inject()(
 
     for {
       is5mldEnabled <- featureFlagService.is5mldEnabled()
-      isUnderlyingData5mld <- trustsConnector.isTrust5mld(answers.identifier)
+      trustDetails <- trustsConnector.getUntransformedTrustDetails(answers.identifier)
     } yield {
-      val updatedAnswers = answers.copy(is5mldEnabled = is5mldEnabled, isUnderlyingData5mld = isUnderlyingData5mld)
+      val updatedAnswers = answers.copy(is5mldEnabled = is5mldEnabled, isUnderlyingData5mld = trustDetails.is5mld)
 
       def answersCombined: Either[PlaybackExtractionError, Option[UserAnswers]] = for {
         correspondence <- correspondenceExtractor.extract(updatedAnswers, data.correspondence).right

--- a/app/mapping/UserAnswersExtractor.scala
+++ b/app/mapping/UserAnswersExtractor.scala
@@ -59,7 +59,12 @@ class UserAnswersExtractorImpl @Inject()(
       is5mldEnabled <- featureFlagService.is5mldEnabled()
       trustDetails <- trustsConnector.getUntransformedTrustDetails(answers.identifier)
     } yield {
-      val updatedAnswers = answers.copy(is5mldEnabled = is5mldEnabled, isUnderlyingData5mld = trustDetails.is5mld)
+
+      val updatedAnswers = answers.copy(
+        is5mldEnabled = is5mldEnabled,
+        isUnderlyingData5mld = trustDetails.is5mld,
+        isUnderlyingDataTaxable = trustDetails.isTaxable
+      )
 
       def answersCombined: Either[PlaybackExtractionError, Option[UserAnswers]] = for {
         correspondence <- correspondenceExtractor.extract(updatedAnswers, data.correspondence).right

--- a/app/mapping/UserAnswersExtractor.scala
+++ b/app/mapping/UserAnswersExtractor.scala
@@ -17,6 +17,7 @@
 package mapping
 
 import com.google.inject.{ImplementedBy, Inject}
+import connectors.TrustConnector
 import mapping.PlaybackExtractionErrors.{FailedToCombineAnswers, PlaybackExtractionError}
 import mapping.beneficiaries.BeneficiaryExtractor
 import mapping.protectors.ProtectorExtractor
@@ -39,6 +40,7 @@ trait UserAnswersExtractor {
 
 class UserAnswersExtractorImpl @Inject()(
                                           featureFlagService: FeatureFlagService,
+                                          trustsConnector: TrustConnector,
                                           beneficiariesExtractor: BeneficiaryExtractor,
                                           trusteesExtractor: TrusteeExtractor,
                                           settlorsExtractor: SettlorExtractor,
@@ -53,35 +55,36 @@ class UserAnswersExtractorImpl @Inject()(
   def extract(answers: UserAnswers, data: GetTrust)
              (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Either[PlaybackExtractionError, UserAnswers]] = {
 
-    featureFlagService.is5mldEnabled() map {
-      is5mldEnabled =>
+    for {
+      is5mldEnabled <- featureFlagService.is5mldEnabled()
+      isUnderlyingData5mld <- trustsConnector.isTrust5mld(answers.identifier)
+    } yield {
+      val updatedAnswers = answers.copy(is5mldEnabled = is5mldEnabled, isUnderlyingData5mld = isUnderlyingData5mld)
 
-        val updatedAnswers = answers.copy(isTrustTaxable = data.trust.details.isTaxable, is5mldEnabled = is5mldEnabled)
+      def answersCombined: Either[PlaybackExtractionError, Option[UserAnswers]] = for {
+        correspondence <- correspondenceExtractor.extract(updatedAnswers, data.correspondence).right
+        beneficiaries <- beneficiariesExtractor.extract(updatedAnswers, data.trust.entities.beneficiary).right
+        settlors <- settlorsExtractor.extract(updatedAnswers, data.trust.entities).right
+        assets <- nonEeaBusinessAssetExtractor.extract(updatedAnswers, data.trust.assets.map(_.nonEEABusiness).getOrElse(Nil)).right
+        trustType <- trustTypeExtractor.extract(updatedAnswers, data.trust).right
+        protectors <- protectorsExtractor.extract(updatedAnswers, data.trust.entities.protectors).right
+        otherIndividuals <- otherIndividualsExtractor.extract(updatedAnswers, data.trust.entities.naturalPerson.getOrElse(Nil)).right
+        trustees <- trusteesExtractor.extract(updatedAnswers, data.trust.entities).right
+        trustDetails <- trustDetailsExtractor.extract(updatedAnswers, data.trust.details).right
+      } yield {
+        List(correspondence, beneficiaries, settlors, assets, trustType, protectors, otherIndividuals, trustees, trustDetails).combine
+      }
 
-        def answersCombined: Either[PlaybackExtractionError, Option[UserAnswers]] = for {
-          trustDetails <- trustDetailsExtractor.extract(updatedAnswers, data.trust.details).right
-          correspondence <- correspondenceExtractor.extract(trustDetails, data.correspondence).right
-          beneficiaries <- beneficiariesExtractor.extract(trustDetails, data.trust.entities.beneficiary).right
-          settlors <- settlorsExtractor.extract(trustDetails, data.trust.entities).right
-          assets <- nonEeaBusinessAssetExtractor.extract(trustDetails, data.trust.assets.map(_.nonEEABusiness).getOrElse(Nil)).right
-          trustType <- trustTypeExtractor.extract(trustDetails, data.trust).right
-          protectors <- protectorsExtractor.extract(trustDetails, data.trust.entities.protectors).right
-          otherIndividuals <- otherIndividualsExtractor.extract(trustDetails, data.trust.entities.naturalPerson.getOrElse(Nil)).right
-          trustees <- trusteesExtractor.extract(trustDetails, data.trust.entities).right
-        } yield {
-          List(correspondence, beneficiaries, settlors, assets, trustType, protectors, otherIndividuals, trustees, trustDetails).combine
-        }
-
-        answersCombined match {
-          case Left(error) =>
-            logger.error(s"[UTR/URN: ${answers.identifier}] failed to unpack data to user answers, failed for $error")
-            Left(error)
-          case Right(None) =>
-            logger.error(s"[UTR/URN: ${answers.identifier}] failed to combine user answers")
-            Left(FailedToCombineAnswers)
-          case Right(Some(ua)) =>
-            Right(ua)
-        }
+      answersCombined match {
+        case Left(error) =>
+          logger.error(s"[UTR/URN: ${answers.identifier}] failed to unpack data to user answers, failed for $error")
+          Left(error)
+        case Right(None) =>
+          logger.error(s"[UTR/URN: ${answers.identifier}] failed to combine user answers")
+          Left(FailedToCombineAnswers)
+        case Right(Some(ua)) =>
+          Right(ua)
+      }
     }
   }
 }

--- a/app/models/TrustDetails.scala
+++ b/app/models/TrustDetails.scala
@@ -20,7 +20,12 @@ import play.api.libs.json.{Format, Json}
 
 import java.time.LocalDate
 
-case class TrustDetails(startDate: LocalDate)
+case class TrustDetails(startDate: LocalDate, trustTaxable: Option[Boolean], expressTrust: Option[Boolean]) {
+
+  def is5mld: Boolean = expressTrust.isDefined
+
+  def isTaxable: Boolean = !trustTaxable.contains(false)
+}
 
 object TrustDetails {
 

--- a/app/models/TrustDetails.scala
+++ b/app/models/TrustDetails.scala
@@ -18,7 +18,9 @@ package models
 
 import play.api.libs.json.{Format, Json}
 
-case class TrustDetails(startDate: String)
+import java.time.LocalDate
+
+case class TrustDetails(startDate: LocalDate)
 
 object TrustDetails {
 

--- a/app/models/TrustTaxability.scala
+++ b/app/models/TrustTaxability.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+sealed trait TrustTaxability
+
+case object Taxable extends TrustTaxability
+case object NonTaxable extends TrustTaxability
+case object MigratingFromNonTaxableToTaxable extends TrustTaxability
+case object MigratingFromTaxableToNonTaxable extends TrustTaxability

--- a/app/models/UserAnswers.scala
+++ b/app/models/UserAnswers.scala
@@ -32,20 +32,21 @@ final case class UserAnswers(internalId: String,
                              data: JsObject = Json.obj(),
                              is5mldEnabled: Boolean = false,
                              isUnderlyingData5mld: Boolean = false,
+                             isUnderlyingDataTaxable: Boolean = true,
                              updatedAt: LocalDateTime = LocalDateTime.now) extends Logging {
 
   def identifierType: IdentifierType = if (identifier.matches(Validation.utrRegex)) UTR else URN
 
-  def trustTaxability: TrustTaxability = (this.get(WhatIsNextPage), identifierType) match {
+  def trustTaxability: TrustTaxability = (this.get(WhatIsNextPage), isUnderlyingDataTaxable) match {
     case (Some(NeedsToPayTax), _) => MigratingFromNonTaxableToTaxable
     case (Some(NoLongerTaxable), _) => MigratingFromTaxableToNonTaxable
-    case (_, UTR) => Taxable
-    case (_, URN) => NonTaxable
+    case (_, true) => Taxable
+    case (_, false) => NonTaxable
   }
 
-  def isTrustTaxable: Boolean = trustTaxability == Taxable
+  def isTrustTaxable: Boolean = trustTaxability == Taxable || trustTaxability == MigratingFromNonTaxableToTaxable
 
-  def trustMldStatus: TrustMldStatus = (is5mldEnabled, isUnderlyingData5mld, isTrustTaxable) match {
+  def trustMldStatus: TrustMldStatus = (is5mldEnabled, isUnderlyingData5mld, isUnderlyingDataTaxable) match {
     case (false, _, _) => Underlying4mldTrustIn4mldMode
     case (true, false, _) => Underlying4mldTrustIn5mldMode
     case (true, true, true) => Underlying5mldTaxableTrustIn5mldMode
@@ -129,12 +130,17 @@ final case class UserAnswers(internalId: String,
 
 object UserAnswers {
 
-  def startNewSession(internalId: String, identifier: String, is5mldEnabled: Boolean, isUnderlyingData5mld: Boolean): UserAnswers =
+  def startNewSession(internalId: String,
+                      identifier: String,
+                      is5mldEnabled: Boolean,
+                      isUnderlyingData5mld: Boolean,
+                      isUnderlyingDataTaxable: Boolean): UserAnswers =
     UserAnswers(
       internalId = internalId,
       identifier = identifier,
       is5mldEnabled = is5mldEnabled,
-      isUnderlyingData5mld = isUnderlyingData5mld
+      isUnderlyingData5mld = isUnderlyingData5mld,
+      isUnderlyingDataTaxable = isUnderlyingDataTaxable
     )
 
   implicit lazy val reads: Reads[UserAnswers] = (
@@ -143,15 +149,17 @@ object UserAnswers {
       (__ \ "data").read[JsObject] and
       (__ \ "is5mldEnabled").readWithDefault[Boolean](false) and
       (__ \ "isUnderlyingData5mld").readWithDefault[Boolean](false) and
+      (__ \ "isUnderlyingDataTaxable").readWithDefault[Boolean](true) and
       (__ \ "updatedAt").read(MongoDateTimeFormats.localDateTimeRead)
     )(UserAnswers.apply _)
 
-  implicit lazy val writes: OWrites[UserAnswers] = (
+  implicit lazy val writes: Writes[UserAnswers] = (
     (__ \ "internalId").write[String] and
       (__ \ "identifier").write[String] and
       (__ \ "data").write[JsObject] and
       (__ \ "is5mldEnabled").write[Boolean] and
       (__ \ "isUnderlyingData5mld").write[Boolean] and
+      (__ \ "isUnderlyingDataTaxable").write[Boolean] and
       (__ \ "updatedAt").write(MongoDateTimeFormats.localDateTimeWrite)
     )(unlift(UserAnswers.unapply))
 }

--- a/app/models/http/TrustsResponse.scala
+++ b/app/models/http/TrustsResponse.scala
@@ -32,9 +32,9 @@ case object SorryThereHasBeenAProblem extends TrustStatus
 case object IdentifierNotFound extends TrustsResponse
 case object TrustServiceUnavailable extends TrustsResponse
 case object ClosedRequestResponse extends TrustsResponse
-case object ServerError extends TrustsResponse
+case object TrustsErrorResponse extends TrustsResponse
 
-object TrustsStatusReads extends Logging {
+object TrustsResponse extends Logging {
 
   final val CLOSED_REQUEST = 499
 
@@ -60,7 +60,7 @@ object TrustsStatusReads extends Logging {
     }
   }
 
-  private def validatedProcessedStatus(json: JsValue) : JsResult[Processed] = {
+  private def validatedProcessedStatus(json: JsValue): JsResult[Processed] = {
     json("getTrust").validate[GetTrust] match {
       case JsSuccess(trust, _) =>
         val formBundle = json("responseHeader")("formBundleNo").as[String]
@@ -72,7 +72,7 @@ object TrustsStatusReads extends Logging {
   }
 
   implicit lazy val httpReads: HttpReads[TrustsResponse] = (_: String, _: String, response: HttpResponse) => {
-    logger.info(s"[TrustStatus] response status received from trusts status api: ${response.status}")
+    logger.info(s"[TrustsResponse] response status received from trusts status api: ${response.status}")
 
     response.status match {
       case OK =>
@@ -86,7 +86,7 @@ object TrustsStatusReads extends Logging {
       case CLOSED_REQUEST =>
         ClosedRequestResponse
       case _ =>
-        ServerError
+        TrustsErrorResponse
     }
   }
 }

--- a/app/services/DeclarationService.scala
+++ b/app/services/DeclarationService.scala
@@ -16,27 +16,26 @@
 
 package services
 
-import java.time.LocalDate
-
 import com.google.inject.{ImplementedBy, Inject}
 import connectors.TrustConnector
 import mapping.PlaybackImplicits._
-import models.http.{AgentDetails, DeclarationResponse}
+import models.http.{AgentDetails, Declaration, DeclarationForApi, DeclarationResponse}
 import models.{Address, AgentDeclaration, FullName, IndividualDeclaration}
-import play.api.libs.json.{JsValue, Json}
 import uk.gov.hmrc.http.HeaderCarrier
 
+import java.time.LocalDate
 import scala.concurrent.{ExecutionContext, Future}
 
 class DeclarationServiceImpl @Inject()(connector: TrustConnector) extends DeclarationService {
 
-  override def agentDeclaration(utr: String,
-                                declaration: AgentDeclaration,
-                                arn: String,
-                                agencyAddress: Address,
-                                agentFriendlyName: String,
-                                endDate: Option[LocalDate]
-                               )(implicit hc: HeaderCarrier, ec : ExecutionContext): Future[DeclarationResponse] = {
+  override def agentDeclaration(
+                                 utr: String,
+                                 declaration: AgentDeclaration,
+                                 arn: String,
+                                 agencyAddress: Address,
+                                 agentFriendlyName: String,
+                                 endDate: Option[LocalDate]
+                               )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[DeclarationResponse] = {
 
     val agentDetails = AgentDetails(
       arn,
@@ -49,48 +48,38 @@ class DeclarationServiceImpl @Inject()(connector: TrustConnector) extends Declar
     declare(declaration.name, utr, Some(agentDetails), endDate)
   }
 
-  override def individualDeclaration(utr: String,
-                                     declaration: IndividualDeclaration,
-                                     endDate: Option[LocalDate]
-                                    )(implicit hc: HeaderCarrier, ec : ExecutionContext): Future[DeclarationResponse] = {
+  override def individualDeclaration(utr: String, declaration: IndividualDeclaration, endDate: Option[LocalDate])
+                                    (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[DeclarationResponse] = {
 
     declare(declaration.name, utr, None, endDate)
   }
 
-  private def declare(name: FullName, utr: String,
-                      agentDetails: Option[AgentDetails],
-                      endDate: Option[LocalDate]
-                     )(implicit hc: HeaderCarrier, ec : ExecutionContext): Future[DeclarationResponse] = {
+  private def declare(name: FullName, utr: String, agentDetails: Option[AgentDetails], endDate: Option[LocalDate])
+                     (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[DeclarationResponse] = {
 
-    val payload = getPayload(name, agentDetails, endDate)
-    connector.declare(utr, payload)
-  }
-
-  private def getPayload(name: FullName,
-                         agentDetails: Option[AgentDetails],
-                         endDate: Option[LocalDate]): JsValue = {
-    Json.toJson(
-      models.http.DeclarationForApi(
-        models.http.Declaration(name),
-        agentDetails,
-        endDate
-      )
+    val payload = DeclarationForApi(
+      declaration = Declaration(name),
+      agentDetails = agentDetails,
+      endDate = endDate
     )
+
+    connector.declare(utr, payload)
   }
 }
 
 @ImplementedBy(classOf[DeclarationServiceImpl])
 trait DeclarationService {
-  def agentDeclaration(utr: String,
-                       declaration: AgentDeclaration,
-                       arn: String,
-                       agencyAddress: Address,
-                       agentFriendlyName: String,
-                       endDate: Option[LocalDate]
-                      )(implicit hc: HeaderCarrier, ec : ExecutionContext): Future[DeclarationResponse]
 
-  def individualDeclaration(utr: String,
-                            declaration: IndividualDeclaration,
-                            endDate: Option[LocalDate]
-                           )(implicit hc: HeaderCarrier, ec : ExecutionContext): Future[DeclarationResponse]
+  def agentDeclaration(
+                        utr: String,
+                        declaration: AgentDeclaration,
+                        arn: String,
+                        agencyAddress: Address,
+                        agentFriendlyName: String,
+                        endDate: Option[LocalDate]
+                      )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[DeclarationResponse]
+
+  def individualDeclaration(utr: String, declaration: IndividualDeclaration, endDate: Option[LocalDate])
+                           (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[DeclarationResponse]
+
 }

--- a/app/services/UserAnswersSetupService.scala
+++ b/app/services/UserAnswersSetupService.scala
@@ -30,11 +30,11 @@ import scala.concurrent.{ExecutionContext, Future}
 class UserAnswersSetupService @Inject()(playbackRepository: PlaybackRepository,
                                         sessionRepository: ActiveSessionRepository) extends Logging {
 
-  def setupAndRedirectToStatus(identifier: String, internalId: String, is5mldEnabled: Boolean, isTaxable: Boolean)
+  def setupAndRedirectToStatus(identifier: String, internalId: String, is5mldEnabled: Boolean, isUnderlyingData5mld: Boolean)
                               (implicit ec: ExecutionContext, hc: HeaderCarrier): Future[Result] = {
 
     val activeSession = IdentifierSession(internalId, identifier)
-    val newEmptyAnswers = UserAnswers.startNewSession(internalId, identifier, is5mldEnabled, isTaxable)
+    val newEmptyAnswers = UserAnswers.startNewSession(internalId, identifier, is5mldEnabled, isUnderlyingData5mld)
 
     for {
       _ <- playbackRepository.resetCache(internalId, identifier)

--- a/app/services/UserAnswersSetupService.scala
+++ b/app/services/UserAnswersSetupService.scala
@@ -30,11 +30,16 @@ import scala.concurrent.{ExecutionContext, Future}
 class UserAnswersSetupService @Inject()(playbackRepository: PlaybackRepository,
                                         sessionRepository: ActiveSessionRepository) extends Logging {
 
-  def setupAndRedirectToStatus(identifier: String, internalId: String, is5mldEnabled: Boolean, isUnderlyingData5mld: Boolean)
-                              (implicit ec: ExecutionContext, hc: HeaderCarrier): Future[Result] = {
+  def setupAndRedirectToStatus(
+                                identifier: String,
+                                internalId: String,
+                                is5mldEnabled: Boolean,
+                                isUnderlyingData5mld: Boolean,
+                                isUnderlyingDataTaxable: Boolean
+                              )(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[Result] = {
 
     val activeSession = IdentifierSession(internalId, identifier)
-    val newEmptyAnswers = UserAnswers.startNewSession(internalId, identifier, is5mldEnabled, isUnderlyingData5mld)
+    val newEmptyAnswers = UserAnswers.startNewSession(internalId, identifier, is5mldEnabled, isUnderlyingData5mld, isUnderlyingDataTaxable)
 
     for {
       _ <- playbackRepository.resetCache(internalId, identifier)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -497,7 +497,7 @@ declarationWhatNext5mld.generate-pdf.hint = Create a digitally signed PDF, which
 noTaxLiabilityInfo.title = You must contact HMRC
 noTaxLiabilityInfo.heading = You must contact HMRC
 noTaxLiabilityInfo.paragraph1 = If the trust you are maintaining no longer has a tax liability, you need to either:
-noTaxLiabilityInfo.bullet1 = Contact HMRC to let them know that you longer need to declare tax.
+noTaxLiabilityInfo.bullet1 = Contact HMRC to let them know that you no longer need to declare tax.
 noTaxLiabilityInfo.bullet2 = Submit a Self Assessment: Trust and Estate Tax Return (SA900)
 noTaxLiabilityInfo.paragraph2 = You no longer need to make an annual declaration for this trust. You will need to notify us of any changes to the trust details.
 

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -16,6 +16,7 @@
 
 package base
 
+import controllers.Assets.OK
 import controllers.actions._
 import models.UserAnswers
 import org.scalatest.{BeforeAndAfter, TestSuite, TryValues}
@@ -26,6 +27,7 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.BodyParsers
 import repositories.PlaybackRepository
 import uk.gov.hmrc.auth.core.{AffinityGroup, Enrolment, Enrolments}
+import uk.gov.hmrc.http.HttpResponse
 import utils.TestUserAnswers
 
 trait SpecBaseHelpers extends GuiceOneAppPerSuite with TryValues with Mocked with BeforeAndAfter with FakeTrustsApp {
@@ -54,6 +56,9 @@ trait SpecBaseHelpers extends GuiceOneAppPerSuite with TryValues with Mocked wit
         bind[PlaybackRepository].toInstance(playbackRepository)
       )
   }
+
+  val okResponse: HttpResponse = HttpResponse(OK, "")
+
 }
 
 trait SpecBase extends PlaySpec with SpecBaseHelpers

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -17,6 +17,7 @@
 package base
 
 import controllers.actions._
+import models.UserAnswers
 import org.scalatest.{BeforeAndAfter, TestSuite, TryValues}
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice._
@@ -33,10 +34,10 @@ trait SpecBaseHelpers extends GuiceOneAppPerSuite with TryValues with Mocked wit
   final val ENGLISH = "en"
   final val WELSH = "cy"
 
-  def emptyUserAnswersForUtr = TestUserAnswers.emptyUserAnswersForUtr
-  def emptyUserAnswersForUrn = TestUserAnswers.emptyUserAnswersForUrn
+  def emptyUserAnswersForUtr: UserAnswers = TestUserAnswers.emptyUserAnswersForUtr
+  def emptyUserAnswersForUrn: UserAnswers = TestUserAnswers.emptyUserAnswersForUrn
 
-  val bodyParsers = injector.instanceOf[BodyParsers.Default]
+  val bodyParsers: BodyParsers.Default = injector.instanceOf[BodyParsers.Default]
 
   protected def applicationBuilder(userAnswers: Option[models.UserAnswers] = None,
                                    affinityGroup: AffinityGroup = AffinityGroup.Organisation,

--- a/test/connectors/TrustConnectorSpec.scala
+++ b/test/connectors/TrustConnectorSpec.scala
@@ -43,7 +43,7 @@ class TrustConnectorSpec extends FreeSpec with MustMatchers
   private def playbackUrl(utr: String) : String = s"/trusts/$utr/transformed"
   private def declareUrl(utr: String) : String = s"/trusts/declare/$utr"
 
-  private val utr = "1000000008"
+  private val identifier = "1000000008"
 
   "TrustConnector" - {
 
@@ -479,11 +479,11 @@ class TrustConnectorSpec extends FreeSpec with MustMatchers
         val connector = application.injector.instanceOf[TrustConnector]
 
         server.stubFor(
-          get(urlEqualTo(s"/trusts/$utr/transformed/protectors-already-exist"))
+          get(urlEqualTo(s"/trusts/$identifier/transformed/protectors-already-exist"))
             .willReturn(okJson(json.toString))
         )
 
-        val processed = Await.result(connector.getDoProtectorsAlreadyExist(utr), Duration.Inf)
+        val processed = Await.result(connector.getDoProtectorsAlreadyExist(identifier), Duration.Inf)
 
         processed.value mustBe true
 
@@ -503,12 +503,12 @@ class TrustConnectorSpec extends FreeSpec with MustMatchers
         val connector = application.injector.instanceOf[TrustConnector]
 
         server.stubFor(
-          get(urlEqualTo(s"/trusts/$utr/transformed/protectors-already-exist"))
+          get(urlEqualTo(s"/trusts/$identifier/transformed/protectors-already-exist"))
             .willReturn(notFound())
         )
 
         a[UpstreamErrorResponse] mustBe thrownBy {
-          Await.result(connector.getDoProtectorsAlreadyExist(utr), Duration.Inf)
+          Await.result(connector.getDoProtectorsAlreadyExist(identifier), Duration.Inf)
         }
 
         application.stop()
@@ -532,11 +532,11 @@ class TrustConnectorSpec extends FreeSpec with MustMatchers
         val connector = application.injector.instanceOf[TrustConnector]
 
         server.stubFor(
-          get(urlEqualTo(s"/trusts/$utr/transformed/other-individuals-already-exist"))
+          get(urlEqualTo(s"/trusts/$identifier/transformed/other-individuals-already-exist"))
             .willReturn(okJson(json.toString))
         )
 
-        val processed = Await.result(connector.getDoOtherIndividualsAlreadyExist(utr), Duration.Inf)
+        val processed = Await.result(connector.getDoOtherIndividualsAlreadyExist(identifier), Duration.Inf)
 
         processed.value mustBe true
 
@@ -556,12 +556,12 @@ class TrustConnectorSpec extends FreeSpec with MustMatchers
         val connector = application.injector.instanceOf[TrustConnector]
 
         server.stubFor(
-          get(urlEqualTo(s"/trusts/$utr/transformed/other-individuals-already-exist"))
+          get(urlEqualTo(s"/trusts/$identifier/transformed/other-individuals-already-exist"))
             .willReturn(notFound())
         )
 
         a[UpstreamErrorResponse] mustBe thrownBy {
-          Await.result(connector.getDoOtherIndividualsAlreadyExist(utr), Duration.Inf)
+          Await.result(connector.getDoOtherIndividualsAlreadyExist(identifier), Duration.Inf)
         }
 
         application.stop()
@@ -585,11 +585,11 @@ class TrustConnectorSpec extends FreeSpec with MustMatchers
         val connector = application.injector.instanceOf[TrustConnector]
 
         server.stubFor(
-          get(urlEqualTo(s"/trusts/$utr/transformed/non-eea-companies-already-exist"))
+          get(urlEqualTo(s"/trusts/$identifier/transformed/non-eea-companies-already-exist"))
             .willReturn(okJson(json.toString))
         )
 
-        val processed = Await.result(connector.getDoNonEeaCompaniesAlreadyExist(utr), Duration.Inf)
+        val processed = Await.result(connector.getDoNonEeaCompaniesAlreadyExist(identifier), Duration.Inf)
 
         processed.value mustBe true
 
@@ -609,12 +609,12 @@ class TrustConnectorSpec extends FreeSpec with MustMatchers
         val connector = application.injector.instanceOf[TrustConnector]
 
         server.stubFor(
-          get(urlEqualTo(s"/trusts/$utr/transformed/non-eea-companies-already-exist"))
+          get(urlEqualTo(s"/trusts/$identifier/transformed/non-eea-companies-already-exist"))
             .willReturn(notFound())
         )
 
         a[UpstreamErrorResponse] mustBe thrownBy {
-          Await.result(connector.getDoNonEeaCompaniesAlreadyExist(utr), Duration.Inf)
+          Await.result(connector.getDoNonEeaCompaniesAlreadyExist(identifier), Duration.Inf)
         }
 
         application.stop()
@@ -636,12 +636,12 @@ class TrustConnectorSpec extends FreeSpec with MustMatchers
         val connector = application.injector.instanceOf[TrustConnector]
 
         server.stubFor(
-          post(urlEqualTo(s"/trusts/$utr/taxable-migration/migrating-to-taxable"))
+          post(urlEqualTo(s"/trusts/$identifier/taxable-migration/migrating-to-taxable"))
             .withRequestBody(equalTo("true"))
             .willReturn(ok)
         )
 
-        val processed = Await.result(connector.setTaxableMigrationFlag(utr, value = true), Duration.Inf)
+        val processed = Await.result(connector.setTaxableMigrationFlag(identifier, value = true), Duration.Inf)
 
         processed.status mustBe OK
 
@@ -661,11 +661,11 @@ class TrustConnectorSpec extends FreeSpec with MustMatchers
         val connector = application.injector.instanceOf[TrustConnector]
 
         server.stubFor(
-          post(urlEqualTo(s"/trusts/$utr/taxable-migration/migrating-to-taxable"))
+          post(urlEqualTo(s"/trusts/$identifier/taxable-migration/migrating-to-taxable"))
             .willReturn(aResponse().withStatus(BAD_REQUEST))
         )
 
-        val processed = Await.result(connector.setTaxableMigrationFlag(utr, value = true), Duration.Inf)
+        val processed = Await.result(connector.setTaxableMigrationFlag(identifier, value = true), Duration.Inf)
 
         processed.status mustBe BAD_REQUEST
 
@@ -685,12 +685,12 @@ class TrustConnectorSpec extends FreeSpec with MustMatchers
         val connector = application.injector.instanceOf[TrustConnector]
 
         server.stubFor(
-          post(urlEqualTo(s"/trusts/$utr/taxable-migration/migrating-to-taxable"))
+          post(urlEqualTo(s"/trusts/$identifier/taxable-migration/migrating-to-taxable"))
             .withRequestBody(equalTo("true"))
             .willReturn(aResponse().withStatus(INTERNAL_SERVER_ERROR))
         )
 
-        val processed = Await.result(connector.setTaxableMigrationFlag(utr, value = true), Duration.Inf)
+        val processed = Await.result(connector.setTaxableMigrationFlag(identifier, value = true), Duration.Inf)
 
         processed.status mustBe INTERNAL_SERVER_ERROR
 
@@ -713,11 +713,11 @@ class TrustConnectorSpec extends FreeSpec with MustMatchers
         val connector = application.injector.instanceOf[TrustConnector]
 
         server.stubFor(
-          delete(urlEqualTo(s"/trusts/$utr/transforms"))
+          delete(urlEqualTo(s"/trusts/$identifier/transforms"))
             .willReturn(ok)
         )
 
-        val processed = Await.result(connector.removeTransforms(utr), Duration.Inf)
+        val processed = Await.result(connector.removeTransforms(identifier), Duration.Inf)
 
         processed.status mustBe OK
 
@@ -737,11 +737,11 @@ class TrustConnectorSpec extends FreeSpec with MustMatchers
         val connector = application.injector.instanceOf[TrustConnector]
 
         server.stubFor(
-          delete(urlEqualTo(s"/trusts/$utr/transforms"))
+          delete(urlEqualTo(s"/trusts/$identifier/transforms"))
             .willReturn(aResponse().withStatus(INTERNAL_SERVER_ERROR))
         )
 
-        val processed = Await.result(connector.removeTransforms(utr), Duration.Inf)
+        val processed = Await.result(connector.removeTransforms(identifier), Duration.Inf)
 
         processed.status mustBe INTERNAL_SERVER_ERROR
 
@@ -763,11 +763,11 @@ class TrustConnectorSpec extends FreeSpec with MustMatchers
         val connector = application.injector.instanceOf[TrustConnector]
 
         server.stubFor(
-          put(urlEqualTo(s"/trusts/trust-details/$utr/express"))
+          put(urlEqualTo(s"/trusts/trust-details/$identifier/express"))
             .willReturn(ok)
         )
 
-        val result = Await.result(connector.setExpressTrust(utr, value = true), Duration.Inf)
+        val result = Await.result(connector.setExpressTrust(identifier, value = true), Duration.Inf)
 
         result.status mustBe OK
 
@@ -789,15 +789,74 @@ class TrustConnectorSpec extends FreeSpec with MustMatchers
         val connector = application.injector.instanceOf[TrustConnector]
 
         server.stubFor(
-          put(urlEqualTo(s"/trusts/trust-details/$utr/taxable"))
+          put(urlEqualTo(s"/trusts/trust-details/$identifier/taxable"))
             .willReturn(ok)
         )
 
-        val result = Await.result(connector.setTaxableTrust(utr, value = true), Duration.Inf)
+        val result = Await.result(connector.setTaxableTrust(identifier, value = true), Duration.Inf)
 
         result.status mustBe OK
 
         application.stop()
+      }
+    }
+
+    ".isTrust5mld" - {
+
+      "return true" - {
+        "untransformed data is 5mld" in {
+          val json = JsBoolean(true)
+
+          val application = applicationBuilder()
+            .configure(
+              Seq(
+                "microservice.services.trusts.port" -> server.port(),
+                "auditing.enabled" -> false
+              ): _*
+            ).build()
+
+          val connector = application.injector.instanceOf[TrustConnector]
+
+          server.stubFor(
+            get(urlEqualTo(s"/trusts/$identifier/is-trust-5mld"))
+              .willReturn(okJson(json.toString))
+          )
+
+          val processed = connector.isTrust5mld(identifier)
+
+          whenReady(processed) {
+            r =>
+              r mustBe true
+          }
+        }
+      }
+
+      "return false" - {
+        "untransformed data is 4mld" in {
+          val json = JsBoolean(false)
+
+          val application = applicationBuilder()
+            .configure(
+              Seq(
+                "microservice.services.trusts.port" -> server.port(),
+                "auditing.enabled" -> false
+              ): _*
+            ).build()
+
+          val connector = application.injector.instanceOf[TrustConnector]
+
+          server.stubFor(
+            get(urlEqualTo(s"/trusts/$identifier/is-trust-5mld"))
+              .willReturn(okJson(json.toString))
+          )
+
+          val processed = connector.isTrust5mld(identifier)
+
+          whenReady(processed) {
+            r =>
+              r mustBe false
+          }
+        }
       }
     }
   }

--- a/test/controllers/IndexControllerSpec.scala
+++ b/test/controllers/IndexControllerSpec.scala
@@ -17,6 +17,7 @@
 package controllers
 
 import base.SpecBase
+import connectors.TrustConnector
 import controllers.Assets.Redirect
 import org.mockito.Matchers.{any, eq => eqTo}
 import org.mockito.Mockito.{reset, verify, when}
@@ -55,6 +56,7 @@ class IndexControllerSpec extends SpecBase with BeforeAndAfterAll with BeforeAnd
   val redirectUrl = "redirectUrl"
 
   val mockFeatureFlagService: FeatureFlagService = mock[FeatureFlagService]
+  val mockTrustsConnector: TrustConnector = mock[TrustConnector]
   val mockUserAnswersSetupService: UserAnswersSetupService = mock[UserAnswersSetupService]
 
   override def beforeEach(): Unit = {
@@ -68,304 +70,130 @@ class IndexControllerSpec extends SpecBase with BeforeAndAfterAll with BeforeAnd
   "Index Controller" when {
 
     "onPageLoad in 4mld mode" must {
-      "redirect to UTR controller when user is not enrolled (agent)" in {
-
-        when(mockFeatureFlagService.is5mldEnabled()(any(), any())).thenReturn(Future.successful(false))
-
-        val application = applicationBuilder(userAnswers = Some(emptyUserAnswersForUtr)).overrides(
-          bind[FeatureFlagService].toInstance(mockFeatureFlagService)
-        ).build()
-
-        val request = FakeRequest(GET, onPageLoad)
-
-        val result = route(application, request).value
-
-        status(result) mustEqual SEE_OTHER
-
-        redirectLocation(result).value mustBe controllers.routes.UTRController.onPageLoad().url
-
-        application.stop()
-      }
-
-      "redirect to status controller when user is a returning user who is enrolled" in {
-
-        when(mockFeatureFlagService.is5mldEnabled()(any(), any())).thenReturn(Future.successful(false))
-
-        val application = applicationBuilder(
-          userAnswers = Some(emptyUserAnswersForUtr),
-          affinityGroup = AffinityGroup.Organisation,
-          enrolments = taxableEnrolment
-        ).overrides(
-          bind[FeatureFlagService].toInstance(mockFeatureFlagService),
-          bind[UserAnswersSetupService].toInstance(mockUserAnswersSetupService)
-        ).build()
-
-        val request = FakeRequest(GET, onPageLoad)
-
-        val result = route(application, request).value
-
-        status(result) mustEqual SEE_OTHER
-
-        redirectLocation(result).value mustBe redirectUrl
-
-        verify(mockUserAnswersSetupService).setupAndRedirectToStatus(
-          eqTo(utr),
-          eqTo("id"),
-          eqTo(false),
-          eqTo(true)
-        )(any(), any())
-
-        application.stop()
-      }
+      behave like taskListController(
+        is5mldEnabled = false,
+        isUnderlyingData5mld = false,
+        onPageLoadRoute = onPageLoad,
+        redirectRoute = controllers.routes.UTRController.onPageLoad().url
+      )
     }
 
     "onPageLoad in 5mld mode" must {
-      "redirect to UTR controller when user is not enrolled (agent)" in {
-
-        when(mockFeatureFlagService.is5mldEnabled()(any(), any())).thenReturn(Future.successful(true))
-
-        val application = applicationBuilder(userAnswers = Some(emptyUserAnswersForUtr)).overrides(
-          bind[FeatureFlagService].toInstance(mockFeatureFlagService)
-        ).build()
-
-        val request = FakeRequest(GET, onPageLoad)
-
-        val result = route(application, request).value
-
-        status(result) mustEqual SEE_OTHER
-
-        redirectLocation(result).value mustBe controllers.routes.UTRController.onPageLoad().url
-
-        application.stop()
-      }
-
-      "redirect to status controller when user is a returning taxable user who is enrolled" in {
-
-        when(mockFeatureFlagService.is5mldEnabled()(any(), any())).thenReturn(Future.successful(true))
-
-        val application = applicationBuilder(
-          userAnswers = Some(emptyUserAnswersForUtr),
-          affinityGroup = AffinityGroup.Organisation,
-          enrolments = taxableEnrolment
-        ).overrides(
-          bind[FeatureFlagService].toInstance(mockFeatureFlagService),
-          bind[UserAnswersSetupService].toInstance(mockUserAnswersSetupService)
-        ).build()
-
-        val request = FakeRequest(GET, onPageLoad)
-
-        val result = route(application, request).value
-
-        status(result) mustEqual SEE_OTHER
-
-        redirectLocation(result).value mustBe redirectUrl
-
-        verify(mockUserAnswersSetupService).setupAndRedirectToStatus(
-          eqTo(utr),
-          eqTo("id"),
-          eqTo(true),
-          eqTo(true)
-        )(any(), any())
-
-        application.stop()
-      }
-
-      "redirect to status controller when user is a returning non-taxable user who is enrolled" in {
-
-        when(mockFeatureFlagService.is5mldEnabled()(any(), any())).thenReturn(Future.successful(true))
-
-        val application = applicationBuilder(
-          userAnswers = Some(emptyUserAnswersForUtr),
-          affinityGroup = AffinityGroup.Organisation,
-          enrolments = nonTaxableEnrolment
-        ).overrides(
-          bind[FeatureFlagService].toInstance(mockFeatureFlagService),
-          bind[UserAnswersSetupService].toInstance(mockUserAnswersSetupService)
-        ).build()
-
-        val request = FakeRequest(GET, onPageLoad)
-
-        val result = route(application, request).value
-
-        status(result) mustEqual SEE_OTHER
-
-        redirectLocation(result).value mustBe redirectUrl
-
-        verify(mockUserAnswersSetupService).setupAndRedirectToStatus(
-          eqTo(urn),
-          eqTo("id"),
-          eqTo(true),
-          eqTo(false)
-        )(any(), any())
-
-        application.stop()
-      }
+      behave like taskListController(
+        is5mldEnabled = true,
+        isUnderlyingData5mld = true,
+        onPageLoadRoute = onPageLoad,
+        redirectRoute = controllers.routes.UTRController.onPageLoad().url
+      )
     }
 
     "startUtr in 5mld mode" must {
-      "redirect to UTR controller when user is not enrolled (agent)" in {
-
-        when(mockFeatureFlagService.is5mldEnabled()(any(), any())).thenReturn(Future.successful(true))
-
-        val application = applicationBuilder(userAnswers = Some(emptyUserAnswersForUtr)).overrides(
-          bind[FeatureFlagService].toInstance(mockFeatureFlagService)
-        ).build()
-
-        val request = FakeRequest(GET, startUtr)
-
-        val result = route(application, request).value
-
-        status(result) mustEqual SEE_OTHER
-
-        redirectLocation(result).value mustBe controllers.routes.UTRController.onPageLoad().url
-
-        application.stop()
-      }
-
-      "redirect to status controller when user is a returning taxable user who is enrolled" in {
-
-        when(mockFeatureFlagService.is5mldEnabled()(any(), any())).thenReturn(Future.successful(true))
-
-        val application = applicationBuilder(
-          userAnswers = Some(emptyUserAnswersForUtr),
-          affinityGroup = AffinityGroup.Organisation,
-          enrolments = taxableEnrolment
-        ).overrides(
-          bind[FeatureFlagService].toInstance(mockFeatureFlagService),
-          bind[UserAnswersSetupService].toInstance(mockUserAnswersSetupService)
-        ).build()
-
-        val request = FakeRequest(GET, startUtr)
-
-        val result = route(application, request).value
-
-        status(result) mustEqual SEE_OTHER
-
-        redirectLocation(result).value mustBe redirectUrl
-
-        verify(mockUserAnswersSetupService).setupAndRedirectToStatus(
-          eqTo(utr),
-          eqTo("id"),
-          eqTo(true),
-          eqTo(true)
-        )(any(), any())
-
-        application.stop()
-      }
-
-      "redirect to status controller when user is a returning non-taxable user who is enrolled" in {
-
-        when(mockFeatureFlagService.is5mldEnabled()(any(), any())).thenReturn(Future.successful(true))
-
-        val application = applicationBuilder(
-          userAnswers = Some(emptyUserAnswersForUtr),
-          affinityGroup = AffinityGroup.Organisation,
-          enrolments = nonTaxableEnrolment
-        ).overrides(
-          bind[FeatureFlagService].toInstance(mockFeatureFlagService),
-          bind[UserAnswersSetupService].toInstance(mockUserAnswersSetupService)
-        ).build()
-
-        val request = FakeRequest(GET, startUtr)
-
-        val result = route(application, request).value
-
-        status(result) mustEqual SEE_OTHER
-
-        redirectLocation(result).value mustBe redirectUrl
-
-        verify(mockUserAnswersSetupService).setupAndRedirectToStatus(
-          eqTo(urn),
-          eqTo("id"),
-          eqTo(true),
-          eqTo(false)
-        )(any(), any())
-
-        application.stop()
-      }
+      behave like taskListController(
+        is5mldEnabled = true,
+        isUnderlyingData5mld = true,
+        onPageLoadRoute = startUtr,
+        redirectRoute = controllers.routes.UTRController.onPageLoad().url
+      )
     }
 
     "startUrn in 5mld mode" must {
-      "redirect to URN controller when user is not enrolled (agent)" in {
-
-        when(mockFeatureFlagService.is5mldEnabled()(any(), any())).thenReturn(Future.successful(true))
-
-        val application = applicationBuilder(userAnswers = Some(emptyUserAnswersForUtr)).overrides(
-          bind[FeatureFlagService].toInstance(mockFeatureFlagService)
-        ).build()
-
-        val request = FakeRequest(GET, startUrn)
-
-        val result = route(application, request).value
-
-        status(result) mustEqual SEE_OTHER
-
-        redirectLocation(result).value mustBe controllers.routes.URNController.onPageLoad().url
-
-        application.stop()
-      }
-
-      "redirect to status controller when user is a returning taxable user who is enrolled" in {
-
-        when(mockFeatureFlagService.is5mldEnabled()(any(), any())).thenReturn(Future.successful(true))
-
-        val application = applicationBuilder(
-          userAnswers = Some(emptyUserAnswersForUtr),
-          affinityGroup = AffinityGroup.Organisation,
-          enrolments = taxableEnrolment
-        ).overrides(
-          bind[FeatureFlagService].toInstance(mockFeatureFlagService),
-          bind[UserAnswersSetupService].toInstance(mockUserAnswersSetupService)
-        ).build()
-
-        val request = FakeRequest(GET, startUrn)
-
-        val result = route(application, request).value
-
-        status(result) mustEqual SEE_OTHER
-
-        redirectLocation(result).value mustBe redirectUrl
-
-        verify(mockUserAnswersSetupService).setupAndRedirectToStatus(
-          eqTo(utr),
-          eqTo("id"),
-          eqTo(true),
-          eqTo(true)
-        )(any(), any())
-
-        application.stop()
-      }
-
-      "redirect to status controller when user is a returning non-taxable user who is enrolled" in {
-
-        when(mockFeatureFlagService.is5mldEnabled()(any(), any())).thenReturn(Future.successful(true))
-
-        val application = applicationBuilder(
-          userAnswers = Some(emptyUserAnswersForUtr),
-          affinityGroup = AffinityGroup.Organisation,
-          enrolments = nonTaxableEnrolment
-        ).overrides(
-          bind[FeatureFlagService].toInstance(mockFeatureFlagService),
-          bind[UserAnswersSetupService].toInstance(mockUserAnswersSetupService)
-        ).build()
-
-        val request = FakeRequest(GET, startUrn)
-
-        val result = route(application, request).value
-
-        status(result) mustEqual SEE_OTHER
-
-        redirectLocation(result).value mustBe redirectUrl
-
-        verify(mockUserAnswersSetupService).setupAndRedirectToStatus(
-          eqTo(urn),
-          eqTo("id"),
-          eqTo(true),
-          eqTo(false)
-        )(any(), any())
-
-        application.stop()
-      }
+      behave like taskListController(
+        is5mldEnabled = true,
+        isUnderlyingData5mld = true,
+        onPageLoadRoute = startUrn,
+        redirectRoute = controllers.routes.URNController.onPageLoad().url
+      )
     }
+  }
+
+  def taskListController(is5mldEnabled: Boolean, isUnderlyingData5mld: Boolean, onPageLoadRoute: String, redirectRoute: String): Unit = {
+
+    s"redirect to $redirectRoute when user is not enrolled (agent)" in {
+
+      when(mockFeatureFlagService.is5mldEnabled()(any(), any())).thenReturn(Future.successful(is5mldEnabled))
+      when(mockTrustsConnector.isTrust5mld(any())(any(), any())).thenReturn(Future.successful(isUnderlyingData5mld))
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswersForUtr)).overrides(
+        bind[FeatureFlagService].toInstance(mockFeatureFlagService),
+        bind[TrustConnector].toInstance(mockTrustsConnector)
+      ).build()
+
+      val request = FakeRequest(GET, onPageLoadRoute)
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustBe redirectRoute
+
+      application.stop()
+    }
+
+    "redirect to status controller when user is a returning taxable user who is enrolled" in {
+
+      when(mockFeatureFlagService.is5mldEnabled()(any(), any())).thenReturn(Future.successful(is5mldEnabled))
+      when(mockTrustsConnector.isTrust5mld(any())(any(), any())).thenReturn(Future.successful(isUnderlyingData5mld))
+
+      val application = applicationBuilder(
+        userAnswers = Some(emptyUserAnswersForUtr),
+        affinityGroup = AffinityGroup.Organisation,
+        enrolments = taxableEnrolment
+      ).overrides(
+        bind[FeatureFlagService].toInstance(mockFeatureFlagService),
+        bind[UserAnswersSetupService].toInstance(mockUserAnswersSetupService),
+        bind[TrustConnector].toInstance(mockTrustsConnector)
+      ).build()
+
+      val request = FakeRequest(GET, onPageLoadRoute)
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustBe redirectUrl
+
+      verify(mockUserAnswersSetupService).setupAndRedirectToStatus(
+        eqTo(utr),
+        eqTo("id"),
+        eqTo(is5mldEnabled),
+        eqTo(isUnderlyingData5mld)
+      )(any(), any())
+
+      application.stop()
+    }
+
+    "redirect to status controller when user is a returning non-taxable user who is enrolled" in {
+
+      when(mockFeatureFlagService.is5mldEnabled()(any(), any())).thenReturn(Future.successful(is5mldEnabled))
+      when(mockTrustsConnector.isTrust5mld(any())(any(), any())).thenReturn(Future.successful(isUnderlyingData5mld))
+
+      val application = applicationBuilder(
+        userAnswers = Some(emptyUserAnswersForUtr),
+        affinityGroup = AffinityGroup.Organisation,
+        enrolments = nonTaxableEnrolment
+      ).overrides(
+        bind[FeatureFlagService].toInstance(mockFeatureFlagService),
+        bind[UserAnswersSetupService].toInstance(mockUserAnswersSetupService),
+        bind[TrustConnector].toInstance(mockTrustsConnector)
+      ).build()
+
+      val request = FakeRequest(GET, onPageLoadRoute)
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      redirectLocation(result).value mustBe redirectUrl
+
+      verify(mockUserAnswersSetupService).setupAndRedirectToStatus(
+        eqTo(urn),
+        eqTo("id"),
+        eqTo(is5mldEnabled),
+        eqTo(isUnderlyingData5mld)
+      )(any(), any())
+
+      application.stop()
+    }
+
   }
 }

--- a/test/controllers/IndexControllerSpec.scala
+++ b/test/controllers/IndexControllerSpec.scala
@@ -70,7 +70,7 @@ class IndexControllerSpec extends SpecBase with BeforeAndAfterAll with BeforeAnd
   "Index Controller" when {
 
     "onPageLoad in 4mld mode" must {
-      behave like taskListController(
+      behave like indexController(
         is5mldEnabled = false,
         isUnderlyingData5mld = false,
         onPageLoadRoute = onPageLoad,
@@ -79,7 +79,7 @@ class IndexControllerSpec extends SpecBase with BeforeAndAfterAll with BeforeAnd
     }
 
     "onPageLoad in 5mld mode" must {
-      behave like taskListController(
+      behave like indexController(
         is5mldEnabled = true,
         isUnderlyingData5mld = true,
         onPageLoadRoute = onPageLoad,
@@ -88,7 +88,7 @@ class IndexControllerSpec extends SpecBase with BeforeAndAfterAll with BeforeAnd
     }
 
     "startUtr in 5mld mode" must {
-      behave like taskListController(
+      behave like indexController(
         is5mldEnabled = true,
         isUnderlyingData5mld = true,
         onPageLoadRoute = startUtr,
@@ -97,7 +97,7 @@ class IndexControllerSpec extends SpecBase with BeforeAndAfterAll with BeforeAnd
     }
 
     "startUrn in 5mld mode" must {
-      behave like taskListController(
+      behave like indexController(
         is5mldEnabled = true,
         isUnderlyingData5mld = true,
         onPageLoadRoute = startUrn,
@@ -106,7 +106,7 @@ class IndexControllerSpec extends SpecBase with BeforeAndAfterAll with BeforeAnd
     }
   }
 
-  def taskListController(is5mldEnabled: Boolean, isUnderlyingData5mld: Boolean, onPageLoadRoute: String, redirectRoute: String): Unit = {
+  def indexController(is5mldEnabled: Boolean, isUnderlyingData5mld: Boolean, onPageLoadRoute: String, redirectRoute: String): Unit = {
 
     s"redirect to $redirectRoute when user is not enrolled (agent)" in {
 

--- a/test/controllers/InformationMaintainingThisTrustControllerSpec.scala
+++ b/test/controllers/InformationMaintainingThisTrustControllerSpec.scala
@@ -18,7 +18,6 @@ package controllers
 
 import base.SpecBase
 import models.{URN, UTR}
-import pages.trustdetails.ExpressTrustYesNoPage
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import views.html.{InformationMaintainingNonTaxableTrustView, InformationMaintainingTaxableTrustView, InformationMaintainingThisTrustView}
@@ -31,7 +30,7 @@ class InformationMaintainingThisTrustControllerSpec extends SpecBase {
 
       "4mld" in {
 
-        val userAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = false, isTrustTaxable = true)
+        val userAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = false, isUnderlyingData5mld = false)
 
         val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -53,7 +52,7 @@ class InformationMaintainingThisTrustControllerSpec extends SpecBase {
 
         "underlying trust data is 4mld" in {
 
-          val userAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isTrustTaxable = true)
+          val userAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = false)
 
           val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -75,8 +74,7 @@ class InformationMaintainingThisTrustControllerSpec extends SpecBase {
 
           "taxable" in {
 
-            val userAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isTrustTaxable = true)
-              .set(ExpressTrustYesNoPage, true).success.value
+            val userAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
             val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -96,8 +94,7 @@ class InformationMaintainingThisTrustControllerSpec extends SpecBase {
 
           "non-taxable" in {
 
-            val userAnswers = emptyUserAnswersForUrn.copy(is5mldEnabled = true, isTrustTaxable = false)
-              .set(ExpressTrustYesNoPage, true).success.value
+            val userAnswers = emptyUserAnswersForUrn
 
             val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 

--- a/test/controllers/TrustStatusControllerSpec.scala
+++ b/test/controllers/TrustStatusControllerSpec.scala
@@ -279,7 +279,7 @@ class TrustStatusControllerSpec extends SpecBase with BeforeAndAfterEach {
         when(fakeTrustStoreConnector.get(any[String])(any(), any()))
           .thenReturn(Future.successful(Some(TrustClaim("utr", trustLocked = false, managedByAgent = false))))
 
-        when(fakeTrustConnector.playbackFromEtmp(any[String])(any(), any())).thenReturn(Future.successful(ServerError))
+        when(fakeTrustConnector.playbackFromEtmp(any[String])(any(), any())).thenReturn(Future.successful(TrustsErrorResponse))
 
         status(result) mustEqual SEE_OTHER
 

--- a/test/controllers/URNControllerSpec.scala
+++ b/test/controllers/URNControllerSpec.scala
@@ -150,7 +150,7 @@ class URNControllerSpec extends SpecBase {
         eqTo(urn.toUpperCase),
         eqTo("id"),
         eqTo(true),
-        eqTo(false)
+        eqTo(true)
       )(any(), any())
 
       application.stop()

--- a/test/controllers/URNControllerSpec.scala
+++ b/test/controllers/URNControllerSpec.scala
@@ -126,7 +126,7 @@ class URNControllerSpec extends SpecBase {
 
       val mockUserAnswersSetupService = mock[UserAnswersSetupService]
 
-      when(mockUserAnswersSetupService.setupAndRedirectToStatus(any(), any(), any(), any())(any(), any()))
+      when(mockUserAnswersSetupService.setupAndRedirectToStatus(any(), any(), any(), any(), any())(any(), any()))
         .thenReturn(Future.successful(Redirect("redirectUrl")))
 
       val application =
@@ -150,7 +150,8 @@ class URNControllerSpec extends SpecBase {
         eqTo(urn.toUpperCase),
         eqTo("id"),
         eqTo(true),
-        eqTo(true)
+        eqTo(true),
+        eqTo(false)
       )(any(), any())
 
       application.stop()

--- a/test/controllers/UTRControllerSpec.scala
+++ b/test/controllers/UTRControllerSpec.scala
@@ -17,6 +17,7 @@
 package controllers
 
 import base.SpecBase
+import connectors.TrustConnector
 import controllers.Assets.Redirect
 import forms.UTRFormProvider
 import org.mockito.Matchers.{any, eq => eqTo}
@@ -43,6 +44,7 @@ class UTRControllerSpec extends SpecBase {
   lazy val onSubmit: Call = routes.UTRController.onSubmit()
 
   val mockFeatureFlagService: FeatureFlagService = mock[FeatureFlagService]
+  val mockTrustsConnector: TrustConnector = mock[TrustConnector]
 
   val utr = "0987654321"
 
@@ -55,9 +57,11 @@ class UTRControllerSpec extends SpecBase {
     "return OK and the correct view for a GET" in {
 
       when(mockFeatureFlagService.is5mldEnabled()(any(), any())).thenReturn(Future.successful(false))
+      when(mockTrustsConnector.isTrust5mld(any())(any(), any())).thenReturn(Future.successful(false))
 
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswersForUtr)).overrides(
-        bind[FeatureFlagService].toInstance(mockFeatureFlagService)
+        bind[FeatureFlagService].toInstance(mockFeatureFlagService),
+        bind[TrustConnector].toInstance(mockTrustsConnector)
       ).build()
 
       val request = FakeRequest(GET, trustUTRRoute)
@@ -77,9 +81,11 @@ class UTRControllerSpec extends SpecBase {
     "return OK and the correct view for a GET if no existing data is found (creating a new session)" in {
 
       when(mockFeatureFlagService.is5mldEnabled()(any(), any())).thenReturn(Future.successful(false))
+      when(mockTrustsConnector.isTrust5mld(any())(any(), any())).thenReturn(Future.successful(false))
 
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswersForUtr)).overrides(
-        bind[FeatureFlagService].toInstance(mockFeatureFlagService)
+        bind[FeatureFlagService].toInstance(mockFeatureFlagService),
+        bind[TrustConnector].toInstance(mockTrustsConnector)
       ).build()
 
       val request = FakeRequest(GET, trustUTRRoute)
@@ -99,9 +105,11 @@ class UTRControllerSpec extends SpecBase {
     "redirect to trust status for a POST if no existing data is found (creating a new session)" in {
 
       when(mockFeatureFlagService.is5mldEnabled()(any(), any())).thenReturn(Future.successful(false))
+      when(mockTrustsConnector.isTrust5mld(any())(any(), any())).thenReturn(Future.successful(false))
 
       val application = applicationBuilder(userAnswers = None).overrides(
-        bind[FeatureFlagService].toInstance(mockFeatureFlagService)
+        bind[FeatureFlagService].toInstance(mockFeatureFlagService),
+        bind[TrustConnector].toInstance(mockTrustsConnector)
       ).build()
 
       val request = FakeRequest(POST, trustUTRRoute)
@@ -119,6 +127,7 @@ class UTRControllerSpec extends SpecBase {
     "redirect to trust status on a POST" in {
 
       when(mockFeatureFlagService.is5mldEnabled()(any(), any())).thenReturn(Future.successful(false))
+      when(mockTrustsConnector.isTrust5mld(any())(any(), any())).thenReturn(Future.successful(false))
 
       val application =
         applicationBuilder(
@@ -126,7 +135,8 @@ class UTRControllerSpec extends SpecBase {
           affinityGroup = Organisation,
           enrolments = enrolments
         ).overrides(
-          bind[FeatureFlagService].toInstance(mockFeatureFlagService)
+          bind[FeatureFlagService].toInstance(mockFeatureFlagService),
+          bind[TrustConnector].toInstance(mockTrustsConnector)
         ).build()
 
       implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] = FakeRequest(POST, trustUTRRoute)
@@ -148,6 +158,7 @@ class UTRControllerSpec extends SpecBase {
         .thenReturn(Future.successful(Redirect("redirectUrl")))
 
       when(mockFeatureFlagService.is5mldEnabled()(any(), any())).thenReturn(Future.successful(true))
+      when(mockTrustsConnector.isTrust5mld(any())(any(), any())).thenReturn(Future.successful(true))
 
       val application =
         applicationBuilder(
@@ -156,7 +167,8 @@ class UTRControllerSpec extends SpecBase {
           enrolments = enrolments
         ).overrides(
           bind[UserAnswersSetupService].toInstance(mockUserAnswersSetupService),
-          bind[FeatureFlagService].toInstance(mockFeatureFlagService)
+          bind[FeatureFlagService].toInstance(mockFeatureFlagService),
+          bind[TrustConnector].toInstance(mockTrustsConnector)
         ).build()
 
       implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] =
@@ -180,9 +192,11 @@ class UTRControllerSpec extends SpecBase {
     "return a Bad Request and errors when invalid data is submitted" in {
 
       when(mockFeatureFlagService.is5mldEnabled()(any(), any())).thenReturn(Future.successful(false))
+      when(mockTrustsConnector.isTrust5mld(any())(any(), any())).thenReturn(Future.successful(false))
 
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswersForUtr)).overrides(
-        bind[FeatureFlagService].toInstance(mockFeatureFlagService)
+        bind[FeatureFlagService].toInstance(mockFeatureFlagService),
+        bind[TrustConnector].toInstance(mockTrustsConnector)
       ).build()
 
       val request = FakeRequest(POST, trustUTRRoute)

--- a/test/controllers/WhatIsNextControllerSpec.scala
+++ b/test/controllers/WhatIsNextControllerSpec.scala
@@ -283,48 +283,58 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
         "taxable" must {
           "redirect to date the last asset was shared out" in {
 
-            beforeTest()
+            val gen = arbitrary[WhatIsNext]
 
-            val userAnswers = emptyUserAnswersForUtr
+            forAll(gen) { previousAnswer =>
+              beforeTest()
 
-            val application = applicationBuilder(userAnswers = Some(userAnswers))
-              .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
-              .build()
+              val userAnswers = emptyUserAnswersForUtr
+                .set(WhatIsNextPage, previousAnswer).success.value
 
-            implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] = FakeRequest(POST, onSubmit.url)
-              .withFormUrlEncodedBody(("value", CloseTrust.toString))
+              val application = applicationBuilder(userAnswers = Some(userAnswers))
+                .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
+                .build()
 
-            val result = route(application, request).value
+              implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] = FakeRequest(POST, onSubmit.url)
+                .withFormUrlEncodedBody(("value", CloseTrust.toString))
 
-            status(result) mustEqual SEE_OTHER
+              val result = route(application, request).value
 
-            redirectLocation(result).value mustBe controllers.close.taxable.routes.DateLastAssetSharedOutYesNoController.onPageLoad().url
+              status(result) mustEqual SEE_OTHER
 
-            application.stop()
+              redirectLocation(result).value mustBe controllers.close.taxable.routes.DateLastAssetSharedOutYesNoController.onPageLoad().url
+
+              application.stop()
+            }
           }
         }
 
         "non-taxable" must {
           "redirect to date the trust was closed" in {
 
-            beforeTest()
+            val gen = arbitrary[WhatIsNext]
 
-            val userAnswers = emptyUserAnswersForUrn
+            forAll(gen) { previousAnswer =>
+              beforeTest()
 
-            val application = applicationBuilder(userAnswers = Some(userAnswers))
-              .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
-              .build()
+              val userAnswers = emptyUserAnswersForUrn
+                .set(WhatIsNextPage, previousAnswer).success.value
 
-            implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] = FakeRequest(POST, onSubmit.url)
-              .withFormUrlEncodedBody(("value", CloseTrust.toString))
+              val application = applicationBuilder(userAnswers = Some(userAnswers))
+                .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
+                .build()
 
-            val result = route(application, request).value
+              implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] = FakeRequest(POST, onSubmit.url)
+                .withFormUrlEncodedBody(("value", CloseTrust.toString))
 
-            status(result) mustEqual SEE_OTHER
+              val result = route(application, request).value
 
-            redirectLocation(result).value mustBe controllers.close.nontaxable.routes.DateClosedController.onPageLoad().url
+              status(result) mustEqual SEE_OTHER
 
-            application.stop()
+              redirectLocation(result).value mustBe controllers.close.nontaxable.routes.DateClosedController.onPageLoad().url
+
+              application.stop()
+            }
           }
         }
       }

--- a/test/controllers/WhatIsNextControllerSpec.scala
+++ b/test/controllers/WhatIsNextControllerSpec.scala
@@ -29,7 +29,6 @@ import org.scalacheck.Arbitrary.arbitrary
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import pages.WhatIsNextPage
-import pages.trustdetails.ExpressTrustYesNoPage
 import play.api.data.Form
 import play.api.inject.bind
 import play.api.mvc.{AnyContentAsFormUrlEncoded, Call}
@@ -207,7 +206,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
 
               beforeTest()
 
-              val userAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isTrustTaxable = true)
+              val userAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = false)
 
               val application = applicationBuilder(userAnswers = Some(userAnswers))
                 .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
@@ -233,8 +232,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
 
                 beforeTest()
 
-                val userAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isTrustTaxable = true)
-                  .set(ExpressTrustYesNoPage, false).success.value
+                val userAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
                 val application = applicationBuilder(userAnswers = Some(userAnswers))
                   .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
@@ -256,8 +254,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
 
                 beforeTest()
 
-                val userAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isTrustTaxable = false)
-                  .set(ExpressTrustYesNoPage, false).success.value
+                val userAnswers = emptyUserAnswersForUrn
 
                 val application = applicationBuilder(userAnswers = Some(userAnswers))
                   .overrides(bind[TrustConnector].toInstance(mockTrustConnector))

--- a/test/controllers/close/nontaxable/DateClosedControllerSpec.scala
+++ b/test/controllers/close/nontaxable/DateClosedControllerSpec.scala
@@ -24,7 +24,6 @@ import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import pages.close.nontaxable.DateClosedPage
-import pages.trustdetails.ExpressTrustYesNoPage
 import play.api.data.Form
 import play.api.inject.bind
 import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded}
@@ -104,8 +103,7 @@ class DateClosedControllerSpec extends SpecBase with MockitoSugar {
 
     "redirect to the next page when valid data is submitted" in {
 
-      val baseAnswers: UserAnswers = emptyUserAnswersForUrn.copy(is5mldEnabled = true, isTrustTaxable = false)
-        .set(ExpressTrustYesNoPage, true).success.value
+      val baseAnswers: UserAnswers = emptyUserAnswersForUrn
 
       when(fakeConnector.getStartDate(any())(any(), any())).thenReturn(Future.successful(trustStartDate))
 

--- a/test/controllers/close/taxable/DateLastAssetSharedOutControllerSpec.scala
+++ b/test/controllers/close/taxable/DateLastAssetSharedOutControllerSpec.scala
@@ -24,7 +24,6 @@ import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import pages.close.taxable.DateLastAssetSharedOutPage
-import pages.trustdetails.ExpressTrustYesNoPage
 import play.api.data.Form
 import play.api.inject.bind
 import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded}
@@ -109,7 +108,7 @@ class DateLastAssetSharedOutControllerSpec extends SpecBase with MockitoSugar {
 
       "4mld" in {
 
-        val baseAnswers: UserAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = false, isTrustTaxable = true)
+        val baseAnswers: UserAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = false, isUnderlyingData5mld = false)
 
         when(fakeConnector.getStartDate(any())(any(), any())).thenReturn(Future.successful(trustStartDate))
 
@@ -130,7 +129,7 @@ class DateLastAssetSharedOutControllerSpec extends SpecBase with MockitoSugar {
 
         "underlying data is 4mld" in {
 
-          val baseAnswers: UserAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isTrustTaxable = true)
+          val baseAnswers: UserAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = false)
 
           when(fakeConnector.getStartDate(any())(any(), any())).thenReturn(Future.successful(trustStartDate))
 
@@ -149,8 +148,7 @@ class DateLastAssetSharedOutControllerSpec extends SpecBase with MockitoSugar {
 
         "underlying data is 5mld" in {
 
-          val baseAnswers: UserAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isTrustTaxable = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val baseAnswers: UserAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           when(fakeConnector.getStartDate(any())(any(), any())).thenReturn(Future.successful(trustStartDate))
 

--- a/test/controllers/makechanges/AddNonEeaCompanyYesNoControllerSpec.scala
+++ b/test/controllers/makechanges/AddNonEeaCompanyYesNoControllerSpec.scala
@@ -25,7 +25,6 @@ import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import pages.WhatIsNextPage
 import pages.makechanges._
-import pages.trustdetails.ExpressTrustYesNoPage
 import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -43,9 +42,8 @@ class AddNonEeaCompanyYesNoControllerSpec extends SpecBase {
 
   lazy val addNonEeaCompanyYesNoRoute = routes.AddNonEeaCompanyYesNoController.onPageLoad().url
 
-  val baseAnswers: UserAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isTrustTaxable = true)
+  val baseAnswers: UserAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
     .set(WhatIsNextPage, MakeChanges).success.value
-    .set(ExpressTrustYesNoPage, false).success.value
 
   "AddNonEeaCompanyYesNo Controller" when {
 

--- a/test/controllers/makechanges/AddOtherIndividualsYesNoControllerSpec.scala
+++ b/test/controllers/makechanges/AddOtherIndividualsYesNoControllerSpec.scala
@@ -25,7 +25,6 @@ import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import pages.WhatIsNextPage
 import pages.makechanges._
-import pages.trustdetails.ExpressTrustYesNoPage
 import play.api.data.Form
 import play.api.inject.bind
 import play.api.libs.json.JsBoolean
@@ -45,7 +44,7 @@ class AddOtherIndividualsYesNoControllerSpec extends SpecBase {
 
   lazy val addOtherIndividualsYesNoRoute: String = routes.AddOtherIndividualsYesNoController.onPageLoad().url
 
-  val baseAnswers: UserAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = false, isTrustTaxable = true)
+  val baseAnswers: UserAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = false, isUnderlyingData5mld = false)
     .set(WhatIsNextPage, MakeChanges).success.value
 
   "AddOtherIndividualsYesNo Controller" when {
@@ -197,8 +196,7 @@ class AddOtherIndividualsYesNoControllerSpec extends SpecBase {
 
     "in 5mld mode with a 5mld taxable trust" must {
 
-      val baseAnswers5mldTaxable = baseAnswers.copy(is5mldEnabled = true, isTrustTaxable = true)
-        .set(ExpressTrustYesNoPage, false).success.value
+      val baseAnswers5mldTaxable = baseAnswers.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
       "return OK and the correct view for a GET" in {
 

--- a/test/controllers/makechanges/UpdateNonEeaCompanyYesNoControllerSpec.scala
+++ b/test/controllers/makechanges/UpdateNonEeaCompanyYesNoControllerSpec.scala
@@ -25,7 +25,6 @@ import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import pages.WhatIsNextPage
 import pages.makechanges._
-import pages.trustdetails.ExpressTrustYesNoPage
 import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -43,9 +42,8 @@ class UpdateNonEeaCompanyYesNoControllerSpec extends SpecBase {
 
   lazy val updateNonEeaCompanyYesNoRoute = routes.UpdateNonEeaCompanyYesNoController.onPageLoad().url
 
-  val baseAnswers: UserAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isTrustTaxable = true)
+  val baseAnswers: UserAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
     .set(WhatIsNextPage, MakeChanges).success.value
-    .set(ExpressTrustYesNoPage, false).success.value
 
   "UpdateNonEeaCompanyYesNo Controller" when {
 

--- a/test/controllers/makechanges/UpdateOtherIndividualsYesNoControllerSpec.scala
+++ b/test/controllers/makechanges/UpdateOtherIndividualsYesNoControllerSpec.scala
@@ -19,13 +19,12 @@ package controllers.makechanges
 import base.SpecBase
 import connectors.{TrustConnector, TrustsStoreConnector}
 import forms.YesNoFormProvider
-import models.{CompletedMaintenanceTasks, UserAnswers}
 import models.pages.WhatIsNext
+import models.{CompletedMaintenanceTasks, UserAnswers}
 import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import pages.WhatIsNextPage
 import pages.makechanges._
-import pages.trustdetails.ExpressTrustYesNoPage
 import play.api.data.Form
 import play.api.inject.bind
 import play.api.libs.json.{JsArray, JsBoolean}
@@ -166,8 +165,7 @@ class UpdateOtherIndividualsYesNoControllerSpec extends SpecBase {
 
     "in 5mld mode for a 5mld taxable trust" must {
 
-      val baseAnswers5mldTaxable = baseAnswers.copy(is5mldEnabled = true, isTrustTaxable = true)
-        .set(ExpressTrustYesNoPage, false).success.value
+      val baseAnswers5mldTaxable = baseAnswers.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
       
       "return OK and the correct view for a GET" in {
 
@@ -237,7 +235,7 @@ class UpdateOtherIndividualsYesNoControllerSpec extends SpecBase {
 
       "redirect to update a non eea company yes no page when valid data is submitted and an eea company already exists" in {
 
-        val userAnswers = baseAnswers5mldTaxable.copy(is5mldEnabled = true, isTrustTaxable = true)
+        val userAnswers = baseAnswers5mldTaxable
           .set(NonEeaBusinessAsset, JsArray()).success.value
           .set(UpdateTrusteesYesNoPage, false).success.value
           .set(UpdateBeneficiariesYesNoPage, false).success.value

--- a/test/controllers/tasklist/TaskListControllerSpec.scala
+++ b/test/controllers/tasklist/TaskListControllerSpec.scala
@@ -24,7 +24,6 @@ import models.{CompletedMaintenanceTasks, UserAnswers}
 import org.mockito.Matchers.any
 import org.mockito.Mockito._
 import pages.WhatIsNextPage
-import pages.trustdetails.ExpressTrustYesNoPage
 import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.FakeRequest
@@ -70,7 +69,7 @@ class TaskListControllerSpec extends SpecBase {
 
     "in 4mld mode" must {
 
-      val baseAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = false, isTrustTaxable = true)
+      val baseAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = false, isUnderlyingData5mld = false)
 
       val utr = baseAnswers.identifier
 
@@ -81,7 +80,7 @@ class TaskListControllerSpec extends SpecBase {
 
       "underlying trust data is 4mld" must {
 
-        val baseAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isTrustTaxable = true)
+        val baseAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = false)
 
         val utr = baseAnswers.identifier
 
@@ -92,8 +91,7 @@ class TaskListControllerSpec extends SpecBase {
 
         "trust is taxable" must {
 
-          val baseAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isTrustTaxable = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val baseAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val utr = baseAnswers.identifier
 
@@ -102,8 +100,7 @@ class TaskListControllerSpec extends SpecBase {
 
         "trust is non-taxable" must {
 
-          val baseAnswers = emptyUserAnswersForUrn.copy(is5mldEnabled = true, isTrustTaxable = false)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val baseAnswers = emptyUserAnswersForUrn
 
           val urn = baseAnswers.identifier
 

--- a/test/controllers/transition/ConfirmTrustTaxableControllerSpec.scala
+++ b/test/controllers/transition/ConfirmTrustTaxableControllerSpec.scala
@@ -29,7 +29,6 @@ import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AffinityGroup.{Agent, Organisation}
-import uk.gov.hmrc.http.HttpResponse
 import views.html.transition.ConfirmTrustTaxableView
 
 import scala.concurrent.Future
@@ -71,7 +70,7 @@ class ConfirmTrustTaxableControllerSpec extends SpecBase with MockitoSugar {
           val mockTrustsConnector = mock[TrustConnector]
 
           when(mockTrustsConnector.setTaxableTrust(any(), any())(any(), any()))
-            .thenReturn(Future.successful(HttpResponse(OK, "")))
+            .thenReturn(Future.successful(okResponse))
 
           val application = applicationBuilder(userAnswers = Some(emptyUserAnswersForUtr), affinityGroup = Agent)
             .overrides(bind[TrustConnector].toInstance(mockTrustsConnector))
@@ -101,7 +100,7 @@ class ConfirmTrustTaxableControllerSpec extends SpecBase with MockitoSugar {
           val mockTrustsConnector = mock[TrustConnector]
 
           when(mockTrustsConnector.setTaxableTrust(any(), any())(any(), any()))
-            .thenReturn(Future.successful(HttpResponse(OK, "")))
+            .thenReturn(Future.successful(okResponse))
 
           val application = applicationBuilder(userAnswers = Some(emptyUserAnswersForUtr), affinityGroup = Organisation)
             .overrides(bind[TrustConnector].toInstance(mockTrustsConnector))

--- a/test/controllers/transition/ExpressTrustYesNoControllerSpec.scala
+++ b/test/controllers/transition/ExpressTrustYesNoControllerSpec.scala
@@ -28,7 +28,6 @@ import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import repositories.PlaybackRepository
-import uk.gov.hmrc.http.HttpResponse
 import views.html.transition.ExpressTrustYesNoView
 
 import scala.concurrent.Future
@@ -90,10 +89,10 @@ class ExpressTrustYesNoControllerSpec extends SpecBase with MockitoSugar {
         .thenReturn(Future.successful(true))
 
       when(mockTrustsConnector.removeTransforms(any())(any(), any()))
-        .thenReturn(Future.successful(HttpResponse(OK, "")))
+        .thenReturn(Future.successful(okResponse))
 
       when(mockTrustsConnector.setExpressTrust(any(), any())(any(), any()))
-        .thenReturn(Future.successful(HttpResponse(OK, "")))
+        .thenReturn(Future.successful(okResponse))
 
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswersForUtr))
         .overrides(bind[TrustConnector].toInstance(mockTrustsConnector))

--- a/test/generators/ModelGenerators.scala
+++ b/test/generators/ModelGenerators.scala
@@ -174,7 +174,7 @@ trait ModelGenerators {
             IdentifierNotFound,
             TrustServiceUnavailable,
             ClosedRequestResponse,
-            ServerError
+            TrustsErrorResponse
           )
         )
       } yield

--- a/test/mapping/CorrespondenceExtractorSpec.scala
+++ b/test/mapping/CorrespondenceExtractorSpec.scala
@@ -18,8 +18,8 @@ package mapping
 
 import base.SpecBaseHelpers
 import generators.Generators
+import models.UKAddress
 import models.http.{AddressType, Correspondence}
-import models.{UKAddress, UserAnswers}
 import org.scalatest.{EitherValues, FreeSpec, MustMatchers}
 import pages.correspondence._
 import pages.trustdetails.TrustNamePage
@@ -44,7 +44,7 @@ class CorrespondenceExtractorSpec extends FreeSpec with MustMatchers with Either
         phoneNumber = "1225645"
       )
 
-      val ua = UserAnswers("fakeId", "utr")
+      val ua = emptyUserAnswersForUtr
 
       val extraction = correspondenceExtractor.extract(ua, correspondence)
 

--- a/test/mapping/NonEeaBusinessAssetExtractorSpec.scala
+++ b/test/mapping/NonEeaBusinessAssetExtractorSpec.scala
@@ -60,7 +60,7 @@ class NonEeaBusinessAssetExtractorSpec extends FreeSpec with MustMatchers
 
         val assets = Nil
 
-        val ua = UserAnswers("fakeId", "utr")
+        val ua = emptyUserAnswersForUtr
 
         val extraction = assetExtractor.extract(ua, assets)
 
@@ -85,7 +85,7 @@ class NonEeaBusinessAssetExtractorSpec extends FreeSpec with MustMatchers
             endDate = None
           ))
 
-          val ua = UserAnswers("fakeId", "utr")
+          val ua = emptyUserAnswersForUtr
 
           val extraction = assetExtractor.extract(ua, nonEeaBusinessAssets)
 
@@ -100,7 +100,7 @@ class NonEeaBusinessAssetExtractorSpec extends FreeSpec with MustMatchers
         "with full data must return user answers updated" in {
           val nonEeaBusinessAssets = (for (index <- 0 to 2) yield generateNonEeaBusiness(index)).toList
 
-          val ua = UserAnswers("fakeId", "utr")
+          val ua = emptyUserAnswersForUtr
 
           val extraction = assetExtractor.extract(ua, nonEeaBusinessAssets)
 
@@ -141,7 +141,7 @@ class NonEeaBusinessAssetExtractorSpec extends FreeSpec with MustMatchers
             endDate = None
           ))
 
-          val ua = UserAnswers("fakeId", "utr")
+          val ua = emptyUserAnswersForUtr
 
           val extraction = assetExtractor.extract(ua, nonEeaBusinessAssets)
 

--- a/test/mapping/NonEeaBusinessAssetExtractorSpec.scala
+++ b/test/mapping/NonEeaBusinessAssetExtractorSpec.scala
@@ -18,8 +18,8 @@ package mapping
 
 import base.SpecBaseHelpers
 import generators.Generators
+import models.InternationalAddress
 import models.http._
-import models.{InternationalAddress, UserAnswers}
 import org.scalatest.{EitherValues, FreeSpec, MustMatchers}
 import pages.assets.nonEeaBusiness._
 
@@ -156,7 +156,7 @@ class NonEeaBusinessAssetExtractorSpec extends FreeSpec with MustMatchers
         "with full data must return user answers updated" in {
           val nonEeaBusinessAssets = (for (index <- 0 to 2) yield generateNonEeaBusiness(index)).toList
 
-          val ua = UserAnswers("fakeId", "urn")
+          val ua = emptyUserAnswersForUrn
 
           val extraction = assetExtractor.extract(ua, nonEeaBusinessAssets)
 

--- a/test/mapping/OtherIndividualExtractorSpec.scala
+++ b/test/mapping/OtherIndividualExtractorSpec.scala
@@ -19,10 +19,9 @@ package mapping
 import base.SpecBaseHelpers
 import generators.Generators
 import models.http.{AddressType, DisplayTrustIdentificationType, NaturalPersonType, PassportType}
-import models.{FullName, InternationalAddress, MetaData, UKAddress, UserAnswers}
+import models.{FullName, InternationalAddress, MetaData, UKAddress}
 import org.scalatest.{EitherValues, FreeSpec, MustMatchers}
 import pages.individual._
-import pages.trustdetails.ExpressTrustYesNoPage
 import utils.Constants.GB
 
 import java.time.LocalDate
@@ -85,7 +84,7 @@ class OtherIndividualExtractorSpec extends FreeSpec with MustMatchers
 
         val individual = Nil
 
-        val ua = UserAnswers("fakeId", "utr")
+        val ua = emptyUserAnswersForUtr
 
         val extraction = individualExtractor.extract(ua, individual)
 
@@ -112,7 +111,7 @@ class OtherIndividualExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr")
+          val ua = emptyUserAnswersForUtr
 
           val extraction = individualExtractor.extract(ua, individual)
 
@@ -153,8 +152,7 @@ class OtherIndividualExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = individualExtractor.extract(ua, individual)
 
@@ -182,8 +180,7 @@ class OtherIndividualExtractorSpec extends FreeSpec with MustMatchers
         "with full data must return user answers updated" in {
           val individuals = (for (index <- 0 to 2) yield generateIndividual(index)).toList
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = individualExtractor.extract(ua, individuals)
 
@@ -282,8 +279,7 @@ class OtherIndividualExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "urn", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = individualExtractor.extract(ua, individual)
 
@@ -311,8 +307,7 @@ class OtherIndividualExtractorSpec extends FreeSpec with MustMatchers
         "with full data must return user answers updated" in {
           val individuals = (for (index <- 0 to 2) yield generateIndividual(index)).toList
 
-          val ua = UserAnswers("fakeId", "urn", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = individualExtractor.extract(ua, individuals)
 

--- a/test/mapping/TrustDetailsExtractorSpec.scala
+++ b/test/mapping/TrustDetailsExtractorSpec.scala
@@ -18,7 +18,6 @@ package mapping
 
 import base.SpecBaseHelpers
 import generators.Generators
-import models.UserAnswers
 import models.http.{NonUKType, ResidentialStatusType, TrustDetailsType, UkType}
 import models.pages.DeedOfVariation.ReplacedWill
 import models.pages.NonResidentType
@@ -59,7 +58,7 @@ class TrustDetailsExtractorSpec extends FreeSpec with MustMatchers with EitherVa
             efrbsStartDate = Some(LocalDate.of(2018, 4, 20))
           )
 
-          val ua = UserAnswers("fakeId", "utr")
+          val ua = emptyUserAnswersForUtr
 
           val extraction = trusteeDetailsExtractor.extract(ua, trust)
 
@@ -94,7 +93,7 @@ class TrustDetailsExtractorSpec extends FreeSpec with MustMatchers with EitherVa
             efrbsStartDate = Some(LocalDate.of(2018, 4, 20))
           )
 
-          val ua = UserAnswers("fakeId", "utr")
+          val ua = emptyUserAnswersForUtr
 
           val extraction = trusteeDetailsExtractor.extract(ua, trust)
 
@@ -134,7 +133,7 @@ class TrustDetailsExtractorSpec extends FreeSpec with MustMatchers with EitherVa
             efrbsStartDate = Some(LocalDate.of(2018, 4, 20))
           )
 
-          val ua = UserAnswers("fakeId", "urn", isTrustTaxable = false)
+          val ua = emptyUserAnswersForUrn
 
           val extraction = trusteeDetailsExtractor.extract(ua, trust)
 
@@ -169,7 +168,7 @@ class TrustDetailsExtractorSpec extends FreeSpec with MustMatchers with EitherVa
             efrbsStartDate = Some(LocalDate.of(2018, 4, 20))
           )
 
-          val ua = UserAnswers("fakeId", "urn", isTrustTaxable = false)
+          val ua = emptyUserAnswersForUrn
 
           val extraction = trusteeDetailsExtractor.extract(ua, trust)
 
@@ -211,7 +210,7 @@ class TrustDetailsExtractorSpec extends FreeSpec with MustMatchers with EitherVa
           efrbsStartDate = Some(LocalDate.of(2018, 4, 20))
         )
 
-        val ua = UserAnswers("fakeId", "utr")
+        val ua = emptyUserAnswersForUtr
 
         val extraction = trusteeDetailsExtractor.extract(ua, trust)
 

--- a/test/mapping/beneficiaries/BeneficiaryExtractorSpec.scala
+++ b/test/mapping/beneficiaries/BeneficiaryExtractorSpec.scala
@@ -21,7 +21,7 @@ import generators.Generators
 import mapping.PlaybackExtractionErrors.FailedToExtractData
 import models.HowManyBeneficiaries.Over1
 import models.http._
-import models.{Description, FullName, MetaData, UKAddress, UserAnswers}
+import models.{Description, FullName, MetaData, UKAddress}
 import org.scalatest.{EitherValues, FreeSpec, MustMatchers}
 import pages.beneficiaries.charity._
 import pages.beneficiaries.classOfBeneficiary._
@@ -30,7 +30,6 @@ import pages.beneficiaries.individual._
 import pages.beneficiaries.large._
 import pages.beneficiaries.other._
 import pages.beneficiaries.trust._
-import pages.trustdetails.ExpressTrustYesNoPage
 import utils.Constants.GB
 
 class BeneficiaryExtractorSpec extends FreeSpec with MustMatchers
@@ -49,7 +48,7 @@ class BeneficiaryExtractorSpec extends FreeSpec with MustMatchers
 
         val beneficiary = DisplayTrustBeneficiaryType(Nil, Nil, Nil, Nil, Nil, Nil, Nil)
 
-        val ua = UserAnswers("fakeId", utr)
+        val ua = emptyUserAnswersForUtr
 
         val extraction = beneficiaryExtractor.extract(ua, beneficiary)
 
@@ -182,8 +181,7 @@ class BeneficiaryExtractorSpec extends FreeSpec with MustMatchers
           )
         )
 
-        val ua = UserAnswers("fakeId", utr, is5mldEnabled = true)
-          .set(ExpressTrustYesNoPage, false).success.value
+        val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
         val extraction = beneficiaryExtractor.extract(ua, beneficiary)
 

--- a/test/mapping/beneficiaries/CharityBeneficiaryExtractorSpec.scala
+++ b/test/mapping/beneficiaries/CharityBeneficiaryExtractorSpec.scala
@@ -19,17 +19,13 @@ package mapping.beneficiaries
 import base.SpecBaseHelpers
 import generators.Generators
 import models.http.{AddressType, DisplayTrustCharityType, DisplayTrustIdentificationOrgType}
-import models.{InternationalAddress, MetaData, UKAddress, UserAnswers}
+import models.{InternationalAddress, MetaData, UKAddress}
 import org.scalatest.{EitherValues, FreeSpec, MustMatchers}
 import pages.beneficiaries.charity._
-import pages.trustdetails.ExpressTrustYesNoPage
 import utils.Constants.GB
 
 class CharityBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
   with EitherValues with Generators with SpecBaseHelpers {
-
-  private val utr: String = "1234567890"
-  private val urn: String = "NTTRUST00000001"
   
   def generateCharity(index: Int, isTaxable: Boolean) = DisplayTrustCharityType(
     lineNo = Some(s"$index"),
@@ -76,7 +72,7 @@ class CharityBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
 
         val charities = Nil
 
-        val ua = UserAnswers("fakeId", utr)
+        val ua = emptyUserAnswersForUtr
 
         val extraction = charityExtractor.extract(ua, charities)
 
@@ -102,7 +98,7 @@ class CharityBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", utr)
+          val ua = emptyUserAnswersForUtr
 
           val extraction = charityExtractor.extract(ua, charity)
 
@@ -135,8 +131,7 @@ class CharityBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", utr, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = charityExtractor.extract(ua, charity)
 
@@ -157,8 +152,7 @@ class CharityBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
         "with full data must return user answers updated" in {
           val charities = (for (index <- 0 to 2) yield generateCharity(index, isTaxable = true)).toList
 
-          val ua = UserAnswers("fakeId", utr, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = charityExtractor.extract(ua, charities)
 
@@ -219,8 +213,7 @@ class CharityBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", urn, isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = charityExtractor.extract(ua, charity)
 
@@ -241,8 +234,7 @@ class CharityBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
         "with full data must return user answers updated" in {
           val charities = (for (index <- 0 to 2) yield generateCharity(index, isTaxable = false)).toList
 
-          val ua = UserAnswers("fakeId", urn, isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = charityExtractor.extract(ua, charities)
 

--- a/test/mapping/beneficiaries/ClassOfBeneficiaryExtractorSpec.scala
+++ b/test/mapping/beneficiaries/ClassOfBeneficiaryExtractorSpec.scala
@@ -18,8 +18,8 @@ package mapping.beneficiaries
 
 import base.SpecBaseHelpers
 import generators.Generators
+import models.MetaData
 import models.http.DisplayTrustUnidentifiedType
-import models.{MetaData, UserAnswers}
 import org.scalatest.{EitherValues, FreeSpec, MustMatchers}
 import pages.beneficiaries.classOfBeneficiary._
 
@@ -55,7 +55,7 @@ class ClassOfBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
 
         val classesOfBeneficiaries = Nil
 
-        val ua = UserAnswers("fakeId", "utr")
+        val ua = emptyUserAnswersForUtr
 
         val extraction = classOfBeneficiaryExtractor.extract(ua, classesOfBeneficiaries)
 
@@ -77,7 +77,7 @@ class ClassOfBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
           entityStart = "2019-11-26"
         ))
 
-        val ua = UserAnswers("fakeId", "utr")
+        val ua = emptyUserAnswersForUtr
 
         val extraction = classOfBeneficiaryExtractor.extract(ua, classOfBeneficiary)
 
@@ -90,7 +90,7 @@ class ClassOfBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
       "with full data must return user answers updated" in {
         val charities = (for(index <- 0 to 2) yield generateClassOfBeneficiary(index)).toList
 
-        val ua = UserAnswers("fakeId", "utr")
+        val ua = emptyUserAnswersForUtr
 
         val extraction = classOfBeneficiaryExtractor.extract(ua, charities)
 

--- a/test/mapping/beneficiaries/CompanyBeneficiaryExtractorSpec.scala
+++ b/test/mapping/beneficiaries/CompanyBeneficiaryExtractorSpec.scala
@@ -19,17 +19,13 @@ package mapping.beneficiaries
 import base.SpecBaseHelpers
 import generators.Generators
 import models.http.{AddressType, DisplayTrustCompanyType, DisplayTrustIdentificationOrgType}
-import models.{InternationalAddress, MetaData, UKAddress, UserAnswers}
+import models.{InternationalAddress, MetaData, UKAddress}
 import org.scalatest.{EitherValues, FreeSpec, MustMatchers}
 import pages.beneficiaries.company._
-import pages.trustdetails.ExpressTrustYesNoPage
 import utils.Constants.GB
 
 class CompanyBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
   with EitherValues with Generators with SpecBaseHelpers {
-
-  private val utr: String = "1234567890"
-  private val urn: String = "NTTRUST00000001"
   
   def generateCompany(index: Int) = DisplayTrustCompanyType(
     lineNo = Some(s"$index"),
@@ -76,7 +72,7 @@ class CompanyBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
 
         val companies = Nil
 
-        val ua = UserAnswers("fakeId", utr)
+        val ua = emptyUserAnswersForUtr
 
         val extraction = companyExtractor.extract(ua, companies)
 
@@ -102,7 +98,7 @@ class CompanyBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", utr)
+          val ua = emptyUserAnswersForUtr
 
           val extraction = companyExtractor.extract(ua, company)
 
@@ -134,8 +130,7 @@ class CompanyBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", utr, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = companyExtractor.extract(ua, company)
 
@@ -155,8 +150,7 @@ class CompanyBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
         "with full data must return user answers updated" in {
           val companies = (for (index <- 0 to 2) yield generateCompany(index)).toList
 
-          val ua = UserAnswers("fakeId", utr, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = companyExtractor.extract(ua, companies)
 
@@ -218,8 +212,7 @@ class CompanyBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", urn, isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = companyExtractor.extract(ua, company)
 
@@ -239,8 +232,7 @@ class CompanyBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
         "with full data must return user answers updated" in {
           val companies = (for (index <- 0 to 2) yield generateCompany(index)).toList
 
-          val ua = UserAnswers("fakeId", urn, isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = companyExtractor.extract(ua, companies)
 

--- a/test/mapping/beneficiaries/IndividualBeneficiaryExtractorSpec.scala
+++ b/test/mapping/beneficiaries/IndividualBeneficiaryExtractorSpec.scala
@@ -20,18 +20,14 @@ import base.SpecBaseHelpers
 import generators.Generators
 import models.http.{AddressType, DisplayTrustIdentificationType, DisplayTrustIndividualDetailsType, PassportType}
 import models.pages.RoleInCompany
-import models.{FullName, InternationalAddress, MetaData, UKAddress, UserAnswers}
+import models.{FullName, InternationalAddress, MetaData, UKAddress}
 import org.scalatest.{EitherValues, FreeSpec, MustMatchers}
 import pages.beneficiaries.individual._
-import pages.trustdetails.ExpressTrustYesNoPage
 import utils.Constants.GB
 
 import java.time.LocalDate
 
 class IndividualBeneficiaryExtractorSpec extends FreeSpec with MustMatchers with EitherValues with Generators with SpecBaseHelpers {
-
-  private val utr: String = "1234567890"
-  private val urn: String = "NTTRUST00000001"
 
   def generateIndividual(index: Int) = DisplayTrustIndividualDetailsType(
     lineNo = Some(s"$index"),
@@ -114,7 +110,7 @@ class IndividualBeneficiaryExtractorSpec extends FreeSpec with MustMatchers with
           entityStart = "2019-11-26"
         ))
 
-        val ua = UserAnswers("fakeId", utr)
+        val ua = emptyUserAnswersForUtr
 
         val extraction = individualExtractor.extract(ua, individual)
 
@@ -152,7 +148,7 @@ class IndividualBeneficiaryExtractorSpec extends FreeSpec with MustMatchers with
 
           val individual = Nil
 
-          val ua = UserAnswers("fakeId", utr)
+          val ua = emptyUserAnswersForUtr
 
           val extraction = individualExtractor.extract(ua, individual)
 
@@ -181,7 +177,7 @@ class IndividualBeneficiaryExtractorSpec extends FreeSpec with MustMatchers with
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", utr)
+          val ua = emptyUserAnswersForUtr
 
           val extraction = individualExtractor.extract(ua, individual)
 
@@ -205,8 +201,7 @@ class IndividualBeneficiaryExtractorSpec extends FreeSpec with MustMatchers with
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", utr, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = individualExtractor.extract(ua, individual)
 
@@ -238,8 +233,7 @@ class IndividualBeneficiaryExtractorSpec extends FreeSpec with MustMatchers with
         "with full data must return user answers updated" in {
           val individuals = (for(index <- 0 to 2) yield generateIndividual(index)).toList
 
-          val ua = UserAnswers("fakeId", utr, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = individualExtractor.extract(ua, individuals)
 
@@ -349,8 +343,7 @@ class IndividualBeneficiaryExtractorSpec extends FreeSpec with MustMatchers with
 
           val individual = Nil
 
-          val ua = UserAnswers("fakeId", urn, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = individualExtractor.extract(ua, individual)
 
@@ -379,8 +372,7 @@ class IndividualBeneficiaryExtractorSpec extends FreeSpec with MustMatchers with
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", urn, isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = individualExtractor.extract(ua, individual)
 
@@ -404,8 +396,7 @@ class IndividualBeneficiaryExtractorSpec extends FreeSpec with MustMatchers with
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", urn, isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = individualExtractor.extract(ua, individual)
 
@@ -434,8 +425,7 @@ class IndividualBeneficiaryExtractorSpec extends FreeSpec with MustMatchers with
         "with full data must return user answers updated" in {
           val individuals = (for(index <- 0 to 2) yield generateIndividual(index)).toList
 
-          val ua = UserAnswers("fakeId", urn, isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = individualExtractor.extract(ua, individuals)
 

--- a/test/mapping/beneficiaries/LargeBeneficiaryExtractorSpec.scala
+++ b/test/mapping/beneficiaries/LargeBeneficiaryExtractorSpec.scala
@@ -20,10 +20,9 @@ import base.SpecBaseHelpers
 import generators.Generators
 import models.HowManyBeneficiaries.{Over1, Over1001, Over201}
 import models.http.{AddressType, DisplayTrustIdentificationOrgType, DisplayTrustLargeType}
-import models.{Description, InternationalAddress, MetaData, UKAddress, UserAnswers}
+import models.{Description, InternationalAddress, MetaData, UKAddress}
 import org.scalatest.{EitherValues, FreeSpec, MustMatchers}
 import pages.beneficiaries.large._
-import pages.trustdetails.ExpressTrustYesNoPage
 import utils.Constants.GB
 
 class LargeBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
@@ -84,7 +83,7 @@ class LargeBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
 
         val largeBeneficiaries = Nil
 
-        val ua = UserAnswers("fakeId", "utr")
+        val ua = emptyUserAnswersForUtr
 
         val extraction = largeBeneficiaryExtractor.extract(ua, largeBeneficiaries)
 
@@ -124,7 +123,7 @@ class LargeBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
             )
           )
 
-          val ua = UserAnswers("fakeId", "utr")
+          val ua = emptyUserAnswersForUtr
 
           val extraction = largeBeneficiaryExtractor.extract(ua, largeBeneficiary)
 
@@ -173,8 +172,7 @@ class LargeBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
             )
           )
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = largeBeneficiaryExtractor.extract(ua, largeBeneficiary)
 
@@ -197,8 +195,7 @@ class LargeBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
         "with full data must return user answers updated" in {
           val largeBeneficiaries = (for (index <- 0 to 2) yield generateLargeBeneficiary(index)).toList
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = largeBeneficiaryExtractor.extract(ua, largeBeneficiaries)
 
@@ -280,8 +277,7 @@ class LargeBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
             )
           )
 
-          val ua = UserAnswers("fakeId", "utr", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = largeBeneficiaryExtractor.extract(ua, largeBeneficiary)
 
@@ -304,8 +300,7 @@ class LargeBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
         "with full data must return user answers updated" in {
           val largeBeneficiaries = (for (index <- 0 to 2) yield generateLargeBeneficiary(index)).toList
 
-          val ua = UserAnswers("fakeId", "utr", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = largeBeneficiaryExtractor.extract(ua, largeBeneficiaries)
 

--- a/test/mapping/beneficiaries/OtherBeneficiaryExtractorSpec.scala
+++ b/test/mapping/beneficiaries/OtherBeneficiaryExtractorSpec.scala
@@ -19,10 +19,9 @@ package mapping.beneficiaries
 import base.SpecBaseHelpers
 import generators.Generators
 import models.http.{AddressType, DisplayTrustOtherType}
-import models.{InternationalAddress, MetaData, UKAddress, UserAnswers}
+import models.{InternationalAddress, MetaData, UKAddress}
 import org.scalatest.{EitherValues, FreeSpec, MustMatchers}
 import pages.beneficiaries.other._
-import pages.trustdetails.ExpressTrustYesNoPage
 import utils.Constants.GB
 
 class OtherBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
@@ -67,7 +66,7 @@ class OtherBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
 
         val others = Nil
 
-        val ua = UserAnswers("fakeId", "utr")
+        val ua = emptyUserAnswersForUtr
 
         val extraction = otherExtractor.extract(ua, others)
 
@@ -93,7 +92,7 @@ class OtherBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr")
+          val ua = emptyUserAnswersForUtr
 
           val extraction = otherExtractor.extract(ua, other)
 
@@ -124,8 +123,7 @@ class OtherBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = otherExtractor.extract(ua, other)
 
@@ -144,8 +142,7 @@ class OtherBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
         "with full data must return user answers updated" in {
           val others = (for (index <- 0 to 2) yield generateOther(index)).toList
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = otherExtractor.extract(ua, others)
 
@@ -208,8 +205,7 @@ class OtherBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = otherExtractor.extract(ua, other)
 
@@ -228,8 +224,7 @@ class OtherBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
         "with full data must return user answers updated" in {
           val others = (for (index <- 0 to 2) yield generateOther(index)).toList
 
-          val ua = UserAnswers("fakeId", "utr", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = otherExtractor.extract(ua, others)
 

--- a/test/mapping/beneficiaries/TrustBeneficiaryExtractorSpec.scala
+++ b/test/mapping/beneficiaries/TrustBeneficiaryExtractorSpec.scala
@@ -19,10 +19,9 @@ package mapping.beneficiaries
 import base.SpecBaseHelpers
 import generators.Generators
 import models.http.{AddressType, DisplayTrustBeneficiaryTrustType, DisplayTrustIdentificationOrgType}
-import models.{InternationalAddress, MetaData, UKAddress, UserAnswers}
+import models.{InternationalAddress, MetaData, UKAddress}
 import org.scalatest.{EitherValues, FreeSpec, MustMatchers}
 import pages.beneficiaries.trust._
-import pages.trustdetails.ExpressTrustYesNoPage
 import utils.Constants.GB
 
 class TrustBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
@@ -73,7 +72,7 @@ class TrustBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
 
         val trusts = Nil
 
-        val ua = UserAnswers("fakeId", "utr")
+        val ua = emptyUserAnswersForUtr
 
         val extraction = trustExtractor.extract(ua, trusts)
 
@@ -99,7 +98,7 @@ class TrustBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr")
+          val ua = emptyUserAnswersForUtr
 
           val extraction = trustExtractor.extract(ua, trust)
 
@@ -132,8 +131,7 @@ class TrustBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = trustExtractor.extract(ua, trust)
 
@@ -154,8 +152,7 @@ class TrustBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
         "with full data must return user answers updated" in {
           val trusts = (for (index <- 0 to 2) yield generateTrust(index)).toList
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = trustExtractor.extract(ua, trusts)
 
@@ -226,8 +223,7 @@ class TrustBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = trustExtractor.extract(ua, trust)
 
@@ -248,8 +244,7 @@ class TrustBeneficiaryExtractorSpec extends FreeSpec with MustMatchers
         "with full data must return user answers updated" in {
           val trusts = (for (index <- 0 to 2) yield generateTrust(index)).toList
 
-          val ua = UserAnswers("fakeId", "utr", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = trustExtractor.extract(ua, trusts)
 

--- a/test/mapping/protectors/ProtectorExtractorSpec.scala
+++ b/test/mapping/protectors/ProtectorExtractorSpec.scala
@@ -20,12 +20,11 @@ import base.SpecBaseHelpers
 import generators.Generators
 import models.http._
 import models.pages.IndividualOrBusiness
-import models.{FullName, MetaData, UserAnswers}
+import models.{FullName, MetaData}
 import org.scalatest.{EitherValues, FreeSpec, MustMatchers}
 import pages.protectors._
 import pages.protectors.business._
 import pages.protectors.individual._
-import pages.trustdetails.ExpressTrustYesNoPage
 import utils.Constants.GB
 
 import java.time.LocalDate
@@ -44,7 +43,7 @@ class ProtectorExtractorSpec extends FreeSpec with MustMatchers
 
         val protector = DisplayTrustProtectorsType(Nil, Nil)
 
-        val ua = UserAnswers("fakeId", "utr")
+        val ua = emptyUserAnswersForUtr
 
         val extraction = protectorExtractor.extract(ua, Some(protector))
 
@@ -54,7 +53,7 @@ class ProtectorExtractorSpec extends FreeSpec with MustMatchers
 
       "must return right given no protector" in {
 
-        val ua = UserAnswers("fakeId", "utr")
+        val ua = emptyUserAnswersForUtr
 
         val extraction = protectorExtractor.extract(ua, None)
 
@@ -110,7 +109,7 @@ class ProtectorExtractorSpec extends FreeSpec with MustMatchers
             protectorCompany = Nil
           )
 
-          val ua = UserAnswers("fakeId", "utr")
+          val ua = emptyUserAnswersForUtr
 
           val extraction = protectorExtractor.extract(ua, Some(protectors))
 
@@ -193,7 +192,7 @@ class ProtectorExtractorSpec extends FreeSpec with MustMatchers
             )
           )
 
-          val ua = UserAnswers("fakeId", "utr")
+          val ua = emptyUserAnswersForUtr
 
           val extraction = protectorExtractor.extract(ua, Some(protectors))
 
@@ -267,7 +266,7 @@ class ProtectorExtractorSpec extends FreeSpec with MustMatchers
             )
           )
 
-          val ua = UserAnswers("fakeId", "utr")
+          val ua = emptyUserAnswersForUtr
 
           val extraction = protectorExtractor.extract(ua, Some(protectors))
 
@@ -352,8 +351,7 @@ class ProtectorExtractorSpec extends FreeSpec with MustMatchers
             protectorCompany = Nil
           )
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = protectorExtractor.extract(ua, Some(protectors))
 
@@ -436,8 +434,7 @@ class ProtectorExtractorSpec extends FreeSpec with MustMatchers
             )
           )
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = protectorExtractor.extract(ua, Some(protectors))
 
@@ -511,8 +508,7 @@ class ProtectorExtractorSpec extends FreeSpec with MustMatchers
             )
           )
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = protectorExtractor.extract(ua, Some(protectors))
 
@@ -597,8 +593,7 @@ class ProtectorExtractorSpec extends FreeSpec with MustMatchers
             protectorCompany = Nil
           )
 
-          val ua = UserAnswers("fakeId", "utr", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = protectorExtractor.extract(ua, Some(protectors))
 
@@ -681,8 +676,7 @@ class ProtectorExtractorSpec extends FreeSpec with MustMatchers
             )
           )
 
-          val ua = UserAnswers("fakeId", "utr", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = protectorExtractor.extract(ua, Some(protectors))
 
@@ -756,8 +750,7 @@ class ProtectorExtractorSpec extends FreeSpec with MustMatchers
             )
           )
 
-          val ua = UserAnswers("fakeId", "utr", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = protectorExtractor.extract(ua, Some(protectors))
 

--- a/test/mapping/settlors/BusinessSettlorExtractorSpec.scala
+++ b/test/mapping/settlors/BusinessSettlorExtractorSpec.scala
@@ -21,10 +21,9 @@ import generators.Generators
 import models.http._
 import models.pages.KindOfBusiness._
 import models.pages.{IndividualOrBusiness, KindOfBusiness}
-import models.{InternationalAddress, MetaData, UKAddress, UserAnswers}
+import models.{InternationalAddress, MetaData, UKAddress}
 import org.scalatest.{EitherValues, FreeSpec, MustMatchers}
 import pages.settlors.living_settlor._
-import pages.trustdetails.ExpressTrustYesNoPage
 import utils.Constants.GB
 
 class BusinessSettlorExtractorSpec extends FreeSpec with MustMatchers
@@ -77,7 +76,7 @@ class BusinessSettlorExtractorSpec extends FreeSpec with MustMatchers
 
         val settlors = Nil
 
-        val ua = UserAnswers("fakeId", "utr")
+        val ua = emptyUserAnswersForUtr
 
         val extraction = businessSettlorExtractor.extract(ua, settlors)
 
@@ -103,7 +102,7 @@ class BusinessSettlorExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr")
+          val ua = emptyUserAnswersForUtr
 
           val extraction = businessSettlorExtractor.extract(ua, settlors)
 
@@ -138,8 +137,7 @@ class BusinessSettlorExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = businessSettlorExtractor.extract(ua, settlors)
 
@@ -162,8 +160,7 @@ class BusinessSettlorExtractorSpec extends FreeSpec with MustMatchers
         "with full data must return user answers updated" in {
           val settlors = (for (index <- 0 to 2) yield generateSettlorCompany(index)).toList
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = businessSettlorExtractor.extract(ua, settlors)
 
@@ -228,8 +225,7 @@ class BusinessSettlorExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = businessSettlorExtractor.extract(ua, settlors)
 
@@ -252,8 +248,7 @@ class BusinessSettlorExtractorSpec extends FreeSpec with MustMatchers
         "with full data must return user answers updated" in {
           val settlors = (for (index <- 0 to 2) yield generateSettlorCompany(index)).toList
 
-          val ua = UserAnswers("fakeId", "utr", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = businessSettlorExtractor.extract(ua, settlors)
 

--- a/test/mapping/settlors/DeceasedSettlorExtractorSpec.scala
+++ b/test/mapping/settlors/DeceasedSettlorExtractorSpec.scala
@@ -19,10 +19,9 @@ package mapping.settlors
 import base.SpecBaseHelpers
 import generators.Generators
 import models.http.{AddressType, DisplayTrustIdentificationType, DisplayTrustWillType, PassportType}
-import models.{FullName, InternationalAddress, MetaData, UKAddress, UserAnswers}
+import models.{FullName, InternationalAddress, MetaData, UKAddress}
 import org.scalatest.{EitherValues, FreeSpec, MustMatchers}
 import pages.settlors.deceased_settlor._
-import pages.trustdetails.ExpressTrustYesNoPage
 import utils.Constants.GB
 
 import java.time.LocalDate
@@ -41,7 +40,7 @@ class DeceasedSettlorExtractorSpec extends FreeSpec with MustMatchers
 
         val deceasedSettlor = Nil
 
-        val ua = UserAnswers("fakeId", "utr")
+        val ua = emptyUserAnswersForUtr
 
         val extraction = deceasedSettlorExtractor.extract(ua, deceasedSettlor)
 
@@ -69,7 +68,7 @@ class DeceasedSettlorExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           )
 
-          val ua = UserAnswers("fakeId", "utr")
+          val ua = emptyUserAnswersForUtr
 
           val extraction = deceasedSettlorExtractor.extract(ua, List(deceasedSettlor))
 
@@ -108,8 +107,7 @@ class DeceasedSettlorExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           )
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = deceasedSettlorExtractor.extract(ua, List(deceasedSettlor))
 
@@ -153,8 +151,7 @@ class DeceasedSettlorExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           )
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = deceasedSettlorExtractor.extract(ua, List(deceasedSettlor))
 
@@ -198,8 +195,7 @@ class DeceasedSettlorExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           )
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = deceasedSettlorExtractor.extract(ua, List(deceasedSettlor))
 
@@ -242,8 +238,7 @@ class DeceasedSettlorExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           )
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = deceasedSettlorExtractor.extract(ua, List(deceasedSettlor))
 
@@ -287,8 +282,7 @@ class DeceasedSettlorExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           )
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = deceasedSettlorExtractor.extract(ua, List(deceasedSettlor))
 
@@ -332,8 +326,7 @@ class DeceasedSettlorExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           )
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = deceasedSettlorExtractor.extract(ua, List(deceasedSettlor))
 
@@ -378,8 +371,7 @@ class DeceasedSettlorExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           )
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = deceasedSettlorExtractor.extract(ua, List(deceasedSettlor))
 
@@ -422,8 +414,7 @@ class DeceasedSettlorExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           )
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = deceasedSettlorExtractor.extract(ua, List(deceasedSettlor))
 
@@ -468,8 +459,7 @@ class DeceasedSettlorExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           )
 
-          val ua = UserAnswers("fakeId", "utr", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = deceasedSettlorExtractor.extract(ua, List(deceasedSettlor))
 
@@ -513,8 +503,7 @@ class DeceasedSettlorExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           )
 
-          val ua = UserAnswers("fakeId", "utr", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = deceasedSettlorExtractor.extract(ua, List(deceasedSettlor))
 
@@ -558,8 +547,7 @@ class DeceasedSettlorExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           )
 
-          val ua = UserAnswers("fakeId", "utr", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = deceasedSettlorExtractor.extract(ua, List(deceasedSettlor))
 
@@ -602,8 +590,7 @@ class DeceasedSettlorExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           )
 
-          val ua = UserAnswers("fakeId", "utr", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = deceasedSettlorExtractor.extract(ua, List(deceasedSettlor))
 
@@ -647,8 +634,7 @@ class DeceasedSettlorExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           )
 
-          val ua = UserAnswers("fakeId", "utr", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = deceasedSettlorExtractor.extract(ua, List(deceasedSettlor))
 
@@ -692,8 +678,7 @@ class DeceasedSettlorExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           )
 
-          val ua = UserAnswers("fakeId", "utr", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = deceasedSettlorExtractor.extract(ua, List(deceasedSettlor))
 
@@ -737,8 +722,7 @@ class DeceasedSettlorExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           )
 
-          val ua = UserAnswers("fakeId", "utr", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = deceasedSettlorExtractor.extract(ua, List(deceasedSettlor))
 
@@ -781,8 +765,7 @@ class DeceasedSettlorExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           )
 
-          val ua = UserAnswers("fakeId", "utr", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = deceasedSettlorExtractor.extract(ua, List(deceasedSettlor))
 

--- a/test/mapping/settlors/IndividualSettlorExtractorSpec.scala
+++ b/test/mapping/settlors/IndividualSettlorExtractorSpec.scala
@@ -21,10 +21,9 @@ import generators.Generators
 import models.http._
 import models.pages.IndividualOrBusiness
 import models.pages.KindOfBusiness._
-import models.{FullName, InternationalAddress, MetaData, UKAddress, UserAnswers}
+import models.{FullName, InternationalAddress, MetaData, UKAddress}
 import org.scalatest.{EitherValues, FreeSpec, MustMatchers}
 import pages.settlors.living_settlor._
-import pages.trustdetails.ExpressTrustYesNoPage
 import utils.Constants.GB
 
 import java.time.LocalDate
@@ -84,7 +83,7 @@ class IndividualSettlorExtractorSpec extends FreeSpec with MustMatchers
 
         val settlors = Nil
 
-        val ua = UserAnswers("fakeId", "utr")
+        val ua = emptyUserAnswersForUtr
 
         val extraction = individualSettlorExtractor.extract(ua, settlors)
 
@@ -111,7 +110,7 @@ class IndividualSettlorExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr")
+          val ua = emptyUserAnswersForUtr
 
           val extraction = individualSettlorExtractor.extract(ua, settlors)
 
@@ -152,8 +151,7 @@ class IndividualSettlorExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = individualSettlorExtractor.extract(ua, settlors)
 
@@ -181,8 +179,7 @@ class IndividualSettlorExtractorSpec extends FreeSpec with MustMatchers
         "with full data must return user answers updated" in {
           val settlors = (for (index <- 0 to 2) yield generateSettlorIndividual(index)).toList
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = individualSettlorExtractor.extract(ua, settlors)
 
@@ -263,8 +260,7 @@ class IndividualSettlorExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = individualSettlorExtractor.extract(ua, settlors)
 
@@ -292,8 +288,7 @@ class IndividualSettlorExtractorSpec extends FreeSpec with MustMatchers
         "with full data must return user answers updated" in {
           val settlors = (for (index <- 0 to 2) yield generateSettlorIndividual(index)).toList
 
-          val ua = UserAnswers("fakeId", "utr", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = individualSettlorExtractor.extract(ua, settlors)
 

--- a/test/mapping/settlors/SettlorExtractorSpec.scala
+++ b/test/mapping/settlors/SettlorExtractorSpec.scala
@@ -22,11 +22,10 @@ import mapping.PlaybackExtractionErrors.FailedToExtractData
 import models.http._
 import models.pages.KindOfBusiness.Trading
 import models.pages.{IndividualOrBusiness, KindOfBusiness}
-import models.{FullName, MetaData, UserAnswers}
+import models.{FullName, MetaData}
 import org.scalatest.{EitherValues, FreeSpec, MustMatchers}
 import pages.settlors.deceased_settlor._
 import pages.settlors.living_settlor._
-import pages.trustdetails.ExpressTrustYesNoPage
 import utils.Constants.GB
 
 class SettlorExtractorSpec extends FreeSpec with MustMatchers
@@ -46,7 +45,7 @@ class SettlorExtractorSpec extends FreeSpec with MustMatchers
           None, DisplayTrustLeadTrusteeType(None, None),
           None, None, None)
 
-        val ua = UserAnswers("fakeId", "utr")
+        val ua = emptyUserAnswersForUtr
 
         val extraction = settlorExtractor.extract(ua, entities)
 
@@ -88,8 +87,7 @@ class SettlorExtractorSpec extends FreeSpec with MustMatchers
           settlors = None
         )
 
-        val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-          .set(ExpressTrustYesNoPage, false).success.value
+        val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
         val extraction = settlorExtractor.extract(ua, entities)
 
@@ -182,8 +180,7 @@ class SettlorExtractorSpec extends FreeSpec with MustMatchers
           ))
         )
 
-        val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-          .set(ExpressTrustYesNoPage, false).success.value
+        val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
         val extraction = settlorExtractor.extract(ua, entities)
 

--- a/test/mapping/settlors/TrustTypeExtractorSpec.scala
+++ b/test/mapping/settlors/TrustTypeExtractorSpec.scala
@@ -18,7 +18,6 @@ package mapping.settlors
 
 import base.SpecBaseHelpers
 import generators.Generators
-import models.UserAnswers
 import models.http._
 import models.pages.{DeedOfVariation, KindOfTrust, TypeOfTrust}
 import org.scalatest.{EitherValues, FreeSpec, MustMatchers}
@@ -31,9 +30,6 @@ import java.time.LocalDate
 class TrustTypeExtractorSpec extends FreeSpec with MustMatchers with EitherValues with Generators with SpecBaseHelpers {
 
   val trustTypeExtractor: TrustTypeExtractor = injector.instanceOf[TrustTypeExtractor]
-
-  val utr = "1234567890"
-  val urn = "NTTRUST00000001"
   
   "Trust Type Extractor" - {
 
@@ -351,7 +347,7 @@ class TrustTypeExtractorSpec extends FreeSpec with MustMatchers with EitherValue
           assets = Some(DisplayTrustAssets(Nil, Nil, Nil, Nil, Nil, Nil, Nil))
         )
 
-        val ua = UserAnswers("fakeId",utr)
+        val ua = emptyUserAnswersForUtr
 
         val extraction = trustTypeExtractor.extract(ua, trust)
 

--- a/test/mapping/settlors/TrustTypeExtractorSpec.scala
+++ b/test/mapping/settlors/TrustTypeExtractorSpec.scala
@@ -70,7 +70,7 @@ class TrustTypeExtractorSpec extends FreeSpec with MustMatchers with EitherValue
 
         "must throw error" in {
 
-          val ua = UserAnswers("fakeId", utr)
+          val ua = emptyUserAnswersForUtr
 
           val extraction = trustTypeExtractor.extract(ua, trust)
 
@@ -110,7 +110,7 @@ class TrustTypeExtractorSpec extends FreeSpec with MustMatchers with EitherValue
         
         "must return user answers" in {
 
-          val ua = UserAnswers("fakeId", urn, isTrustTaxable = false)
+          val ua = emptyUserAnswersForUrn
 
           val extraction = trustTypeExtractor.extract(ua, trust)
 
@@ -151,7 +151,7 @@ class TrustTypeExtractorSpec extends FreeSpec with MustMatchers with EitherValue
           assets = Some(DisplayTrustAssets(Nil, Nil, Nil, Nil, Nil, Nil, Nil))
         )
 
-        val ua = UserAnswers("fakeId", utr)
+        val ua = emptyUserAnswersForUtr
 
         val extraction = trustTypeExtractor.extract(ua, trust)
 
@@ -202,7 +202,7 @@ class TrustTypeExtractorSpec extends FreeSpec with MustMatchers with EitherValue
           assets = Some(DisplayTrustAssets(Nil, Nil, Nil, Nil, Nil, Nil, Nil))
         )
 
-        val ua = UserAnswers("fakeId", utr)
+        val ua = emptyUserAnswersForUtr
 
         val extraction = trustTypeExtractor.extract(ua, trust)
 
@@ -253,7 +253,7 @@ class TrustTypeExtractorSpec extends FreeSpec with MustMatchers with EitherValue
           assets = Some(DisplayTrustAssets(Nil, Nil, Nil, Nil, Nil, Nil, Nil))
         )
 
-        val ua = UserAnswers("fakeId", utr)
+        val ua = emptyUserAnswersForUtr
 
         val extraction = trustTypeExtractor.extract(ua, trust)
 
@@ -304,7 +304,7 @@ class TrustTypeExtractorSpec extends FreeSpec with MustMatchers with EitherValue
           assets = Some(DisplayTrustAssets(Nil, Nil, Nil, Nil, Nil, Nil, Nil))
         )
 
-        val ua = UserAnswers("fakeId", utr)
+        val ua = emptyUserAnswersForUtr
 
         val extraction = trustTypeExtractor.extract(ua, trust)
 
@@ -402,7 +402,7 @@ class TrustTypeExtractorSpec extends FreeSpec with MustMatchers with EitherValue
           assets = Some(DisplayTrustAssets(Nil, Nil, Nil, Nil, Nil, Nil, Nil))
         )
 
-        val ua = UserAnswers("fakeId", utr)
+        val ua = emptyUserAnswersForUtr
 
         val extraction = trustTypeExtractor.extract(ua, trust)
 
@@ -453,7 +453,7 @@ class TrustTypeExtractorSpec extends FreeSpec with MustMatchers with EitherValue
           assets = Some(DisplayTrustAssets(Nil, Nil, Nil, Nil, Nil, Nil, Nil))
         )
 
-        val ua = UserAnswers("fakeId", utr)
+        val ua = emptyUserAnswersForUtr
 
         val extraction = trustTypeExtractor.extract(ua, trust)
 
@@ -504,7 +504,7 @@ class TrustTypeExtractorSpec extends FreeSpec with MustMatchers with EitherValue
           assets = Some(DisplayTrustAssets(Nil, Nil, Nil, Nil, Nil, Nil, Nil))
         )
 
-        val ua = UserAnswers("fakeId", utr)
+        val ua = emptyUserAnswersForUtr
 
         val extraction = trustTypeExtractor.extract(ua, trust)
 

--- a/test/mapping/trustees/IndividualLeadTrusteeExtractorSpec.scala
+++ b/test/mapping/trustees/IndividualLeadTrusteeExtractorSpec.scala
@@ -21,9 +21,8 @@ import generators.Generators
 import mapping.PlaybackExtractionErrors.FailedToExtractData
 import models.http._
 import models.pages.IndividualOrBusiness
-import models.{FullName, MetaData, UserAnswers}
+import models.{FullName, MetaData}
 import org.scalatest.{EitherValues, FreeSpec, MustMatchers}
-import pages.trustdetails.ExpressTrustYesNoPage
 import pages.trustees._
 import utils.Constants.GB
 
@@ -43,7 +42,7 @@ class IndividualLeadTrusteeExtractorSpec extends FreeSpec with MustMatchers
 
         val leadTrustee = Nil
 
-        val ua = UserAnswers("fakeId", "utr")
+        val ua = emptyUserAnswersForUtr
 
         val extraction = leadTrusteeIndExtractor.extract(ua, leadTrustee)
 
@@ -77,7 +76,7 @@ class IndividualLeadTrusteeExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr")
+          val ua = emptyUserAnswersForUtr
 
           val extraction = leadTrusteeIndExtractor.extract(ua, leadTrustee)
 
@@ -128,8 +127,7 @@ class IndividualLeadTrusteeExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = leadTrusteeIndExtractor.extract(ua, leadTrustee)
 
@@ -177,8 +175,7 @@ class IndividualLeadTrusteeExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = leadTrusteeIndExtractor.extract(ua, leadTrustee)
 
@@ -226,8 +223,7 @@ class IndividualLeadTrusteeExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = leadTrusteeIndExtractor.extract(ua, leadTrustee)
 
@@ -276,8 +272,7 @@ class IndividualLeadTrusteeExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = leadTrusteeIndExtractor.extract(ua, leadTrustee)
 
@@ -330,8 +325,7 @@ class IndividualLeadTrusteeExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true, isTrustTaxable = false)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = leadTrusteeIndExtractor.extract(ua, leadTrustee)
 
@@ -379,8 +373,7 @@ class IndividualLeadTrusteeExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true, isTrustTaxable = false)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = leadTrusteeIndExtractor.extract(ua, leadTrustee)
 
@@ -428,8 +421,7 @@ class IndividualLeadTrusteeExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true, isTrustTaxable = false)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = leadTrusteeIndExtractor.extract(ua, leadTrustee)
 
@@ -478,8 +470,7 @@ class IndividualLeadTrusteeExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true, isTrustTaxable = false)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = leadTrusteeIndExtractor.extract(ua, leadTrustee)
 

--- a/test/mapping/trustees/IndividualTrusteeExtractorSpec.scala
+++ b/test/mapping/trustees/IndividualTrusteeExtractorSpec.scala
@@ -20,9 +20,8 @@ import base.SpecBaseHelpers
 import generators.Generators
 import models.http._
 import models.pages.IndividualOrBusiness
-import models.{FullName, InternationalAddress, MetaData, UKAddress, UserAnswers}
+import models.{FullName, InternationalAddress, MetaData, UKAddress}
 import org.scalatest.{EitherValues, FreeSpec, MustMatchers}
-import pages.trustdetails.ExpressTrustYesNoPage
 import pages.trustees._
 import utils.Constants.GB
 
@@ -91,7 +90,7 @@ class IndividualTrusteeExtractorSpec extends FreeSpec with MustMatchers
 
         val trustees = Nil
 
-        val ua = UserAnswers("fakeId", "utr")
+        val ua = emptyUserAnswersForUtr
 
         val extraction = trusteesExtractor.extract(ua, trustees)
 
@@ -119,7 +118,7 @@ class IndividualTrusteeExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr")
+          val ua = emptyUserAnswersForUtr
 
           val extraction = trusteesExtractor.extract(ua, trustees)
 
@@ -163,8 +162,7 @@ class IndividualTrusteeExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = trusteesExtractor.extract(ua, trustees)
 
@@ -194,8 +192,7 @@ class IndividualTrusteeExtractorSpec extends FreeSpec with MustMatchers
         "with full data must return user answers updated" in {
           val trustees = (for (index <- 0 to 2) yield generateTrusteeIndividual(index)).toList
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = trusteesExtractor.extract(ua, trustees)
 
@@ -280,8 +277,7 @@ class IndividualTrusteeExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "urn", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = trusteesExtractor.extract(ua, trustees)
 
@@ -311,8 +307,7 @@ class IndividualTrusteeExtractorSpec extends FreeSpec with MustMatchers
         "with full data must return user answers updated" in {
           val trustees = (for (index <- 0 to 2) yield generateTrusteeIndividual(index)).toList
 
-          val ua = UserAnswers("fakeId", "urn", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = trusteesExtractor.extract(ua, trustees)
 

--- a/test/mapping/trustees/OrganisationLeadTrusteeExtractorSpec.scala
+++ b/test/mapping/trustees/OrganisationLeadTrusteeExtractorSpec.scala
@@ -19,11 +19,10 @@ package mapping.trustees
 import base.SpecBaseHelpers
 import generators.Generators
 import mapping.PlaybackExtractionErrors.FailedToExtractData
+import models.MetaData
 import models.http.{AddressType, DisplayTrustIdentificationOrgType, DisplayTrustLeadTrusteeOrgType}
 import models.pages.IndividualOrBusiness
-import models.{MetaData, UserAnswers}
 import org.scalatest.{EitherValues, FreeSpec, MustMatchers}
-import pages.trustdetails.ExpressTrustYesNoPage
 import pages.trustees._
 import utils.Constants.GB
 
@@ -41,7 +40,7 @@ class OrganisationLeadTrusteeExtractorSpec extends FreeSpec with MustMatchers
 
         val leadTrustee = Nil
 
-        val ua = UserAnswers("fakeId", "utr")
+        val ua = emptyUserAnswersForUtr
 
         val extraction = leadTrusteeOrgExtractor.extract(ua, leadTrustee)
 
@@ -72,7 +71,7 @@ class OrganisationLeadTrusteeExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr")
+          val ua = emptyUserAnswersForUtr
 
           val extraction = leadTrusteeOrgExtractor.extract(ua, leadTrustee)
 
@@ -114,8 +113,7 @@ class OrganisationLeadTrusteeExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = leadTrusteeOrgExtractor.extract(ua, leadTrustee)
 
@@ -154,8 +152,7 @@ class OrganisationLeadTrusteeExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = leadTrusteeOrgExtractor.extract(ua, leadTrustee)
 
@@ -197,8 +194,7 @@ class OrganisationLeadTrusteeExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = leadTrusteeOrgExtractor.extract(ua, leadTrustee)
 
@@ -237,8 +233,7 @@ class OrganisationLeadTrusteeExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = leadTrusteeOrgExtractor.extract(ua, leadTrustee)
 

--- a/test/mapping/trustees/OrganisationTrusteeExtractorSpec.scala
+++ b/test/mapping/trustees/OrganisationTrusteeExtractorSpec.scala
@@ -20,9 +20,8 @@ import base.SpecBaseHelpers
 import generators.Generators
 import models.http._
 import models.pages.IndividualOrBusiness
-import models.{InternationalAddress, MetaData, UKAddress, UserAnswers}
+import models.{InternationalAddress, MetaData, UKAddress}
 import org.scalatest.{EitherValues, FreeSpec, MustMatchers}
-import pages.trustdetails.ExpressTrustYesNoPage
 import pages.trustees._
 import utils.Constants.GB
 
@@ -76,7 +75,7 @@ class OrganisationTrusteeExtractorSpec extends FreeSpec with MustMatchers
 
         val trustees = Nil
 
-        val ua = UserAnswers("fakeId", "utr")
+        val ua = emptyUserAnswersForUtr
 
         val extraction = trusteesExtractor.extract(ua, trustees)
 
@@ -102,7 +101,7 @@ class OrganisationTrusteeExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr")
+          val ua = emptyUserAnswersForUtr
 
           val extraction = trusteesExtractor.extract(ua, trustees)
 
@@ -139,8 +138,7 @@ class OrganisationTrusteeExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = trusteesExtractor.extract(ua, trustees)
 
@@ -165,8 +163,7 @@ class OrganisationTrusteeExtractorSpec extends FreeSpec with MustMatchers
         "with full data must return user answers updated" in {
           val trustees = (for (index <- 0 to 2) yield generateTrusteeCompany(index)).toList
 
-          val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, false).success.value
+          val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
           val extraction = trusteesExtractor.extract(ua, trustees)
 
@@ -230,8 +227,7 @@ class OrganisationTrusteeExtractorSpec extends FreeSpec with MustMatchers
             entityStart = "2019-11-26"
           ))
 
-          val ua = UserAnswers("fakeId", "urn", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = trusteesExtractor.extract(ua, trustees)
 
@@ -256,8 +252,7 @@ class OrganisationTrusteeExtractorSpec extends FreeSpec with MustMatchers
         "with full data must return user answers updated" in {
           val trustees = (for (index <- 0 to 2) yield generateTrusteeCompany(index)).toList
 
-          val ua = UserAnswers("fakeId", "urn", isTrustTaxable = false, is5mldEnabled = true)
-            .set(ExpressTrustYesNoPage, true).success.value
+          val ua = emptyUserAnswersForUrn
 
           val extraction = trusteesExtractor.extract(ua, trustees)
 

--- a/test/mapping/trustees/TrusteeExtractorSpec.scala
+++ b/test/mapping/trustees/TrusteeExtractorSpec.scala
@@ -21,9 +21,8 @@ import generators.Generators
 import mapping.PlaybackExtractionErrors.FailedToExtractData
 import models.http._
 import models.pages.IndividualOrBusiness
-import models.{FullName, MetaData, UserAnswers}
+import models.{FullName, MetaData}
 import org.scalatest.{EitherValues, FreeSpec, MustMatchers}
-import pages.trustdetails.ExpressTrustYesNoPage
 import pages.trustees._
 import utils.Constants.GB
 
@@ -46,7 +45,7 @@ class TrusteeExtractorSpec extends FreeSpec with MustMatchers
           None, None, None
         )
 
-        val ua = UserAnswers("fakeId", "utr")
+        val ua = emptyUserAnswersForUtr
 
         val extraction = trusteeExtractor.extract(ua, leadTrustee)
 
@@ -84,8 +83,7 @@ class TrusteeExtractorSpec extends FreeSpec with MustMatchers
           None, None
         )
 
-        val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-          .set(ExpressTrustYesNoPage, false).success.value
+        val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
         val extraction = trusteeExtractor.extract(ua, leadTrustee)
 
@@ -137,8 +135,7 @@ class TrusteeExtractorSpec extends FreeSpec with MustMatchers
           None, None
         )
 
-        val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-          .set(ExpressTrustYesNoPage, false).success.value
+        val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
         val extraction = trusteeExtractor.extract(ua, leadTrustee)
 
@@ -220,8 +217,7 @@ class TrusteeExtractorSpec extends FreeSpec with MustMatchers
           settlors = None
         )
 
-        val ua = UserAnswers("fakeId", "utr", is5mldEnabled = true)
-          .set(ExpressTrustYesNoPage, false).success.value
+        val ua = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
         val extraction = trusteeExtractor.extract(ua, leadTrustee)
 

--- a/test/models/TrustDetailsSpec.scala
+++ b/test/models/TrustDetailsSpec.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import base.SpecBase
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import java.time.LocalDate
+
+class TrustDetailsSpec extends SpecBase with ScalaCheckPropertyChecks {
+
+  "TrustDetails" when {
+
+    ".is5mld" must {
+
+      "return true when expressTrust is defined" in {
+        forAll(arbitrary[Option[Boolean]], arbitrary[Boolean]) {
+          (trustTaxable, expressTrust) =>
+
+            val trustDetails = TrustDetails(LocalDate.now(), trustTaxable, Some(expressTrust))
+            trustDetails.is5mld mustBe true
+        }
+      }
+
+      "return false when expressTrust is undefined" in {
+        forAll(arbitrary[Option[Boolean]]) {
+          trustTaxable =>
+
+            val trustDetails = TrustDetails(LocalDate.now(), trustTaxable, None)
+            trustDetails.is5mld mustBe false
+        }
+      }
+    }
+
+    ".isTaxable" must {
+
+      "return true" when {
+
+        "trustTaxable undefined" in {
+          forAll(arbitrary[Option[Boolean]]) {
+            expressTrust =>
+
+              val trustDetails = TrustDetails(LocalDate.now(), None, expressTrust)
+              trustDetails.isTaxable mustBe true
+          }
+        }
+
+        "trustTaxable contains true" in {
+          forAll(arbitrary[Option[Boolean]]) {
+            expressTrust =>
+
+              val trustDetails = TrustDetails(LocalDate.now(), Some(true), expressTrust)
+              trustDetails.isTaxable mustBe true
+          }
+        }
+      }
+
+      "return false" when {
+        "trustTaxable contains false" in {
+          forAll(arbitrary[Option[Boolean]]) {
+            expressTrust =>
+
+              val trustDetails = TrustDetails(LocalDate.now(), Some(false), expressTrust)
+              trustDetails.isTaxable mustBe false
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/models/TrustMldStatusSpec.scala
+++ b/test/models/TrustMldStatusSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import base.SpecBase
+import org.scalacheck.Gen
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+class TrustMldStatusSpec extends SpecBase with ScalaCheckPropertyChecks {
+
+  "TrustMldStatus" when {
+
+    ".is5mldTrustIn5mldMode" must {
+
+      "return false when Underlying4mldTrustIn4mldMode or Underlying4mldTrustIn5mldMode" in {
+
+        val trustMldStatuses: Seq[TrustMldStatus] = Seq[TrustMldStatus](
+          Underlying4mldTrustIn4mldMode,
+          Underlying4mldTrustIn5mldMode
+        )
+
+        forAll(Gen.oneOf(trustMldStatuses)) {
+          trustMldStatus =>
+            trustMldStatus.is5mldTrustIn5mldMode mustEqual false
+        }
+      }
+
+      "return true when Underlying5mldTaxableTrustIn5mldMode or Underlying5mldNonTaxableTrustIn5mldMode" in {
+
+        val trustMldStatuses: Seq[TrustMldStatus] = Seq[TrustMldStatus](
+          Underlying5mldTaxableTrustIn5mldMode,
+          Underlying5mldNonTaxableTrustIn5mldMode
+        )
+
+        forAll(Gen.oneOf(trustMldStatuses)) {
+          trustMldStatus =>
+            trustMldStatus.is5mldTrustIn5mldMode mustEqual true
+        }
+      }
+    }
+  }
+}

--- a/test/models/UserAnswersSpec.scala
+++ b/test/models/UserAnswersSpec.scala
@@ -19,7 +19,7 @@ package models
 import _root_.pages.WhatIsNextPage
 import base.SpecBase
 import forms.Validation
-import models.pages.WhatIsNext.NeedsToPayTax
+import models.pages.WhatIsNext.{NeedsToPayTax, NoLongerTaxable}
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import wolfendale.scalacheck.regexp.RegexpGen
 
@@ -42,6 +42,33 @@ class UserAnswersSpec extends SpecBase with ScalaCheckPropertyChecks {
           urn =>
             val userAnswers = emptyUserAnswersForUrn.copy(identifier = urn)
             userAnswers.identifierType mustBe URN
+        }
+      }
+    }
+
+    ".trustTaxability" must {
+      "return taxability of trust" when {
+
+        "taxable" in {
+          val userAnswers = emptyUserAnswersForUtr
+          userAnswers.trustTaxability mustBe Taxable
+        }
+
+        "non-taxable" in {
+          val userAnswers = emptyUserAnswersForUrn
+          userAnswers.trustTaxability mustBe NonTaxable
+        }
+
+        "migrating from non-taxable to taxable" in {
+          val userAnswers = emptyUserAnswersForUrn
+            .set(WhatIsNextPage, NeedsToPayTax).success.value
+          userAnswers.trustTaxability mustBe MigratingFromNonTaxableToTaxable
+        }
+
+        "migrating from taxable to non-taxable" in {
+          val userAnswers = emptyUserAnswersForUtr
+            .set(WhatIsNextPage, NoLongerTaxable).success.value
+          userAnswers.trustTaxability mustBe MigratingFromTaxableToNonTaxable
         }
       }
     }

--- a/test/models/UserAnswersSpec.scala
+++ b/test/models/UserAnswersSpec.scala
@@ -73,27 +73,6 @@ class UserAnswersSpec extends SpecBase with ScalaCheckPropertyChecks {
       }
     }
 
-    ".isTrustTaxable" must {
-      "return whether trust is taxable" when {
-
-        "taxable" in {
-          val userAnswers = emptyUserAnswersForUtr
-          userAnswers.isTrustTaxable mustBe true
-        }
-
-        "non-taxable" in {
-          val userAnswers = emptyUserAnswersForUrn
-          userAnswers.isTrustTaxable mustBe false
-        }
-
-        "migrating from non-taxable to taxable" in {
-          val userAnswers = emptyUserAnswersForUrn
-            .set(WhatIsNextPage, NeedsToPayTax).success.value
-          userAnswers.isTrustTaxable mustBe true
-        }
-      }
-    }
-
     ".trustMldStatus" must {
       "return correct MLD status of the trust" when {
 

--- a/test/models/UserAnswersSpec.scala
+++ b/test/models/UserAnswersSpec.scala
@@ -16,15 +16,15 @@
 
 package models
 
+import _root_.pages.WhatIsNextPage
 import base.SpecBase
-import _root_.pages.trustdetails.ExpressTrustYesNoPage
+import models.pages.WhatIsNext.NeedsToPayTax
 
 class UserAnswersSpec extends SpecBase {
 
   "UserAnswers" when {
 
     ".trustMldStatus" must {
-
       "return correct MLD status of the trust" when {
 
         "4mld" in {
@@ -35,24 +35,43 @@ class UserAnswersSpec extends SpecBase {
         "5mld" when {
 
           "underlying data is 4mld" in {
-            val userAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isTrustTaxable = true)
+            val userAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = false)
             userAnswers.trustMldStatus mustBe Underlying4mldTrustIn5mldMode
           }
 
           "underlying data is 5mld" when {
 
             "taxable" in {
-              val userAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isTrustTaxable = true)
-                .set(ExpressTrustYesNoPage, false).success.value
+              val userAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
               userAnswers.trustMldStatus mustBe Underlying5mldTaxableTrustIn5mldMode
             }
 
             "non-taxable" in {
-              val userAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isTrustTaxable = false)
-                .set(ExpressTrustYesNoPage, false).success.value
+              val userAnswers = emptyUserAnswersForUrn
               userAnswers.trustMldStatus mustBe Underlying5mldNonTaxableTrustIn5mldMode
             }
           }
+        }
+      }
+    }
+
+    ".isTrustTaxable" must {
+      "return whether trust is taxable" when {
+
+        "taxable" in {
+          val userAnswers = emptyUserAnswersForUtr
+          userAnswers.isTrustTaxable mustBe true
+        }
+
+        "non-taxable" in {
+          val userAnswers = emptyUserAnswersForUrn
+          userAnswers.isTrustTaxable mustBe false
+        }
+
+        "migrating from non-taxable to taxable" in {
+          val userAnswers = emptyUserAnswersForUrn
+            .set(WhatIsNextPage, NeedsToPayTax).success.value
+          userAnswers.isTrustTaxable mustBe true
         }
       }
     }

--- a/test/models/UserAnswersSpec.scala
+++ b/test/models/UserAnswersSpec.scala
@@ -46,29 +46,33 @@ class UserAnswersSpec extends SpecBase with ScalaCheckPropertyChecks {
       }
     }
 
-    ".trustTaxability" must {
+    ".trustTaxability and .isTrustTaxable" must {
       "return taxability of trust" when {
 
         "taxable" in {
           val userAnswers = emptyUserAnswersForUtr
           userAnswers.trustTaxability mustBe Taxable
+          userAnswers.isTrustTaxable mustBe true
         }
 
         "non-taxable" in {
           val userAnswers = emptyUserAnswersForUrn
           userAnswers.trustTaxability mustBe NonTaxable
+          userAnswers.isTrustTaxable mustBe false
         }
 
         "migrating from non-taxable to taxable" in {
           val userAnswers = emptyUserAnswersForUrn
             .set(WhatIsNextPage, NeedsToPayTax).success.value
           userAnswers.trustTaxability mustBe MigratingFromNonTaxableToTaxable
+          userAnswers.isTrustTaxable mustBe true
         }
 
         "migrating from taxable to non-taxable" in {
           val userAnswers = emptyUserAnswersForUtr
             .set(WhatIsNextPage, NoLongerTaxable).success.value
           userAnswers.trustTaxability mustBe MigratingFromTaxableToNonTaxable
+          userAnswers.isTrustTaxable mustBe false
         }
       }
     }

--- a/test/models/http/TrustsResponseSpec.scala
+++ b/test/models/http/TrustsResponseSpec.scala
@@ -18,92 +18,99 @@ package models.http
 
 import org.scalatest.{MustMatchers, WordSpec}
 import play.api.libs.json.{JsError, Json}
-import TrustsStatusReads._
 
 class TrustsResponseSpec extends WordSpec with MustMatchers {
 
   "trust status" must {
+
     "read from Json" when {
+
       "processing" in {
 
-        val json = """{
-                     |
-                     |  "responseHeader": {
-                     |    "status": "In Processing",
-                     |    "formBundleNo": "1"
-                     |  }
-                     |}
-      """.stripMargin
+        val json =
+          """
+            |{
+            |  "responseHeader": {
+            |    "status": "In Processing",
+            |    "formBundleNo": "1"
+            |  }
+            |}
+            |""".stripMargin
 
         Json.parse(json).as[TrustStatus] mustBe Processing
       }
 
       "closed" in {
 
-        val json = """{
-                     |
-                     |  "responseHeader": {
-                     |    "status": "Closed",
-                     |    "formBundleNo": "1"
-                     |  }
-                     |}
-                 """.stripMargin
+        val json =
+          """
+            |{
+            |  "responseHeader": {
+            |    "status": "Closed",
+            |    "formBundleNo": "1"
+            |  }
+            |}
+            |""".stripMargin
 
         Json.parse(json).as[TrustStatus] mustBe Closed
       }
 
       "pending closure" in {
 
-        val json = """{
-                     |
-                     |  "responseHeader": {
-                     |    "status": "Pending Closure",
-                     |    "formBundleNo": "1"
-                     |  }
-                     |}
-                 """.stripMargin
+        val json =
+          """
+            |{
+            |  "responseHeader": {
+            |    "status": "Pending Closure",
+            |    "formBundleNo": "1"
+            |  }
+            |}
+            |""".stripMargin
 
         Json.parse(json).as[TrustStatus] mustBe Closed
       }
 
       "parked" in {
 
-        val json = """{
-                     |
-                     |  "responseHeader": {
-                     |    "status": "Parked",
-                     |    "formBundleNo": "1"
-                     |  }
-                     |}
-                 """.stripMargin
+        val json =
+          """
+            |{
+            |  "responseHeader": {
+            |    "status": "Parked",
+            |    "formBundleNo": "1"
+            |  }
+            |}
+            |""".stripMargin
 
         Json.parse(json).as[TrustStatus] mustBe SorryThereHasBeenAProblem
       }
 
       "obsoleted" in {
 
-        val json = """{
-                     |
-                     |  "responseHeader": {
-                     |    "status": "Obsoleted",
-                     |    "formBundleNo": "1"
-                     |  }
-                     |}
-                 """.stripMargin
+        val json =
+          """
+            |{
+            |  "responseHeader": {
+            |    "status": "Obsoleted",
+            |    "formBundleNo": "1"
+            |  }
+            |}
+            |""".stripMargin
 
         Json.parse(json).as[TrustStatus] mustBe SorryThereHasBeenAProblem
       }
 
       "suspended" in {
 
-        val json = """{
-                     |
-                     |  "responseHeader": {
-                     |    "status": "Suspended",
-                     |    "formBundleNo": "1"
-                     |  }
-                     |}
-                 """.stripMargin
+        val json =
+          """
+            |{
+            |  "responseHeader": {
+            |    "status": "Suspended",
+            |    "formBundleNo": "1"
+            |  }
+            |}
+            |""".stripMargin
 
         Json.parse(json).as[TrustStatus] mustBe SorryThereHasBeenAProblem
       }
@@ -111,17 +118,17 @@ class TrustsResponseSpec extends WordSpec with MustMatchers {
 
     "return failure when not given expected response" in {
 
-      val json = """{
-                   |
-                   |  "responseHeader": {
-                   |    "status": "SomethingElse",
-                   |    "formBundleNo": "1"
-                   |  }
-                   |}
-                 """.stripMargin
+      val json =
+        """
+          |{
+          |  "responseHeader": {
+          |    "status": "SomethingElse",
+          |    "formBundleNo": "1"
+          |  }
+          |}
+          |""".stripMargin
 
       Json.parse(json).validate[TrustStatus] mustBe JsError("Unexpected Status")
     }
   }
-
 }

--- a/test/services/DeclarationServiceSpec.scala
+++ b/test/services/DeclarationServiceSpec.scala
@@ -15,23 +15,20 @@
  */
 
 package services
-import java.time.LocalDate
-
 import base.SpecBase
 import connectors.TrustConnector
-import models.http.DeclarationResponse.InternalServerError
-import models.http.TVNResponse
+import models.http.{DeclarationForApi, DeclarationErrorResponse, TVNResponse}
 import models.{AgentDeclaration, FullName, IndividualDeclaration, UKAddress}
 import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{EitherValues, RecoverMethods}
 import play.api.inject.bind
-import play.api.libs.json.JsValue
 import uk.gov.hmrc.auth.core.retrieve.AgentInformation
 import uk.gov.hmrc.auth.core.{Enrolment, EnrolmentIdentifier, Enrolments}
 import uk.gov.hmrc.http.HeaderCarrier
 
+import java.time.LocalDate
 import scala.concurrent.Future
 
 class DeclarationServiceSpec extends SpecBase with ScalaFutures with EitherValues with RecoverMethods {
@@ -76,7 +73,7 @@ class DeclarationServiceSpec extends SpecBase with ScalaFutures with EitherValue
 
       "return TVN response when no errors" in {
 
-        when(mockTrustConnector.declare(any[String], any[JsValue])(any(), any()))
+        when(mockTrustConnector.declare(any[String], any[DeclarationForApi])(any(), any()))
           .thenReturn(Future.successful(TVNResponse("123456")))
 
         val app = applicationBuilder()
@@ -93,8 +90,8 @@ class DeclarationServiceSpec extends SpecBase with ScalaFutures with EitherValue
 
       "return InternalServerError when errors" in {
 
-        when(mockTrustConnector.declare(any[String], any[JsValue])(any(), any()))
-          .thenReturn(Future.successful(InternalServerError))
+        when(mockTrustConnector.declare(any[String], any[DeclarationForApi])(any(), any()))
+          .thenReturn(Future.successful(DeclarationErrorResponse))
 
         val app = applicationBuilder()
           .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
@@ -104,7 +101,7 @@ class DeclarationServiceSpec extends SpecBase with ScalaFutures with EitherValue
 
         whenReady(service.agentDeclaration(utr, agentDeclaration, "SARN1234567", address, "agentFriendlyName", Some(date))) {
           result =>
-            result mustBe InternalServerError
+            result mustBe DeclarationErrorResponse
         }
       }
 
@@ -114,7 +111,7 @@ class DeclarationServiceSpec extends SpecBase with ScalaFutures with EitherValue
 
       "return TVN response when no errors" in {
 
-        when(mockTrustConnector.declare(any[String], any[JsValue])(any(), any()))
+        when(mockTrustConnector.declare(any[String], any[DeclarationForApi])(any(), any()))
           .thenReturn(Future.successful(TVNResponse("123456")))
 
         val app = applicationBuilder()
@@ -131,8 +128,8 @@ class DeclarationServiceSpec extends SpecBase with ScalaFutures with EitherValue
 
       "return InternalServerError when errors" in {
 
-        when(mockTrustConnector.declare(any[String], any[JsValue])(any(), any()))
-          .thenReturn(Future.successful(InternalServerError))
+        when(mockTrustConnector.declare(any[String], any[DeclarationForApi])(any(), any()))
+          .thenReturn(Future.successful(DeclarationErrorResponse))
 
         val app = applicationBuilder()
           .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
@@ -142,7 +139,7 @@ class DeclarationServiceSpec extends SpecBase with ScalaFutures with EitherValue
 
         whenReady(service.individualDeclaration(utr, individualDeclaration, Some(date))) {
           result =>
-            result mustBe InternalServerError
+            result mustBe DeclarationErrorResponse
         }
       }
 

--- a/test/services/FakeDeclarationService.scala
+++ b/test/services/FakeDeclarationService.scala
@@ -16,31 +16,31 @@
 
 package services
 
-import java.time.LocalDate
-
-import models.http.DeclarationResponse.InternalServerError
-import models.http.{DeclarationResponse, TVNResponse}
+import models.http.{DeclarationResponse, DeclarationErrorResponse, TVNResponse}
 import models.{Address, AgentDeclaration, IndividualDeclaration}
 import uk.gov.hmrc.http.HeaderCarrier
 
+import java.time.LocalDate
 import scala.concurrent.{ExecutionContext, Future}
 
 class FakeDeclarationService extends DeclarationService {
 
-  override def agentDeclaration(utr: String,
-                                    declaration: AgentDeclaration,
-                                    arn: String,
-                                    agencyAddress: Address,
-                                    agentFriendlyName: String,
-                                    endDate: Option[LocalDate]
-                                   )(implicit hc: HeaderCarrier, ec : ExecutionContext): Future[DeclarationResponse] = {
+  override def agentDeclaration(
+                                 utr: String,
+                                 declaration: AgentDeclaration,
+                                 arn: String,
+                                 agencyAddress: Address,
+                                 agentFriendlyName: String,
+                                 endDate: Option[LocalDate]
+                               )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[DeclarationResponse] = {
     Future.successful(TVNResponse("123456"))
   }
 
-  override def individualDeclaration(utr: String,
-                                     declaration: IndividualDeclaration,
-                                     endDate: Option[LocalDate]
-                                    )(implicit hc: HeaderCarrier, ec : ExecutionContext): Future[DeclarationResponse] = {
+  override def individualDeclaration(
+                                      utr: String,
+                                      declaration: IndividualDeclaration,
+                                      endDate: Option[LocalDate]
+                                    )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[DeclarationResponse] = {
     Future.successful(TVNResponse("123456"))
   }
 
@@ -48,21 +48,23 @@ class FakeDeclarationService extends DeclarationService {
 
 class FakeFailingDeclarationService extends DeclarationService {
 
-  override def agentDeclaration(utr: String,
-                                    declaration: AgentDeclaration,
-                                    arn: String,
-                                    agencyAddress: Address,
-                                    agentFriendlyName: String,
-                                    endDate: Option[LocalDate]
-                                   )(implicit hc: HeaderCarrier, ec : ExecutionContext): Future[DeclarationResponse] = {
-    Future.successful(InternalServerError)
+  override def agentDeclaration(
+                                 utr: String,
+                                 declaration: AgentDeclaration,
+                                 arn: String,
+                                 agencyAddress: Address,
+                                 agentFriendlyName: String,
+                                 endDate: Option[LocalDate]
+                               )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[DeclarationResponse] = {
+    Future.successful(DeclarationErrorResponse)
   }
 
-  override def individualDeclaration(utr: String,
-                                     declaration: IndividualDeclaration,
-                                     endDate: Option[LocalDate]
-                                    )(implicit hc: HeaderCarrier, ec : ExecutionContext): Future[DeclarationResponse] = {
-    Future.successful(InternalServerError)
+  override def individualDeclaration(
+                                      utr: String,
+                                      declaration: IndividualDeclaration,
+                                      endDate: Option[LocalDate]
+                                    )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[DeclarationResponse] = {
+    Future.successful(DeclarationErrorResponse)
   }
 
 }

--- a/test/services/UserAnswersSetupServiceSpec.scala
+++ b/test/services/UserAnswersSetupServiceSpec.scala
@@ -41,8 +41,8 @@ class UserAnswersSetupServiceSpec extends SpecBase with ScalaCheckPropertyChecks
     "setupAndRedirectToStatus" must {
       "setup user answers and redirect to TrustStatusController" in {
 
-        forAll(arbitrary[Boolean], arbitrary[Boolean]) {
-          (is5mldEnabled, isUnderlyingData5mld) =>
+        forAll(arbitrary[Boolean], arbitrary[Boolean], arbitrary[Boolean]) {
+          (is5mldEnabled, isUnderlyingData5mld, isUnderlyingDataTaxable) =>
 
             val mockPlaybackRepository = mock[PlaybackRepository]
             when(mockPlaybackRepository.set(any())).thenReturn(Future.successful(true))
@@ -53,7 +53,13 @@ class UserAnswersSetupServiceSpec extends SpecBase with ScalaCheckPropertyChecks
 
             val userAnswersSetupService = new UserAnswersSetupService(mockPlaybackRepository, mockSessionRepository)
 
-            val result = userAnswersSetupService.setupAndRedirectToStatus(identifier, internalId, is5mldEnabled, isUnderlyingData5mld)
+            val result = userAnswersSetupService.setupAndRedirectToStatus(
+              identifier = identifier,
+              internalId = internalId,
+              is5mldEnabled = is5mldEnabled,
+              isUnderlyingData5mld = isUnderlyingData5mld,
+              isUnderlyingDataTaxable = isUnderlyingDataTaxable
+            )
 
             redirectLocation(result).value mustBe controllers.routes.TrustStatusController.status().url
 
@@ -66,6 +72,7 @@ class UserAnswersSetupServiceSpec extends SpecBase with ScalaCheckPropertyChecks
             uaCaptor.getValue.identifier mustBe identifier
             uaCaptor.getValue.is5mldEnabled mustBe is5mldEnabled
             uaCaptor.getValue.isUnderlyingData5mld mustBe isUnderlyingData5mld
+            uaCaptor.getValue.isUnderlyingDataTaxable mustBe isUnderlyingDataTaxable
 
             val identifierSessionCaptor = ArgumentCaptor.forClass(classOf[IdentifierSession])
             verify(mockSessionRepository).set(identifierSessionCaptor.capture())

--- a/test/services/UserAnswersSetupServiceSpec.scala
+++ b/test/services/UserAnswersSetupServiceSpec.scala
@@ -42,7 +42,7 @@ class UserAnswersSetupServiceSpec extends SpecBase with ScalaCheckPropertyChecks
       "setup user answers and redirect to TrustStatusController" in {
 
         forAll(arbitrary[Boolean], arbitrary[Boolean]) {
-          (is5mldEnabled, isTaxable) =>
+          (is5mldEnabled, isUnderlyingData5mld) =>
 
             val mockPlaybackRepository = mock[PlaybackRepository]
             when(mockPlaybackRepository.set(any())).thenReturn(Future.successful(true))
@@ -53,7 +53,7 @@ class UserAnswersSetupServiceSpec extends SpecBase with ScalaCheckPropertyChecks
 
             val userAnswersSetupService = new UserAnswersSetupService(mockPlaybackRepository, mockSessionRepository)
 
-            val result = userAnswersSetupService.setupAndRedirectToStatus(identifier, internalId, is5mldEnabled, isTaxable)
+            val result = userAnswersSetupService.setupAndRedirectToStatus(identifier, internalId, is5mldEnabled, isUnderlyingData5mld)
 
             redirectLocation(result).value mustBe controllers.routes.TrustStatusController.status().url
 
@@ -65,7 +65,7 @@ class UserAnswersSetupServiceSpec extends SpecBase with ScalaCheckPropertyChecks
             uaCaptor.getValue.internalId mustBe internalId
             uaCaptor.getValue.identifier mustBe identifier
             uaCaptor.getValue.is5mldEnabled mustBe is5mldEnabled
-            uaCaptor.getValue.isTrustTaxable mustBe isTaxable
+            uaCaptor.getValue.isUnderlyingData5mld mustBe isUnderlyingData5mld
 
             val identifierSessionCaptor = ArgumentCaptor.forClass(classOf[IdentifierSession])
             verify(mockSessionRepository).set(identifierSessionCaptor.capture())

--- a/test/utils/TestUserAnswers.scala
+++ b/test/utils/TestUserAnswers.scala
@@ -27,5 +27,5 @@ object TestUserAnswers extends TryValues {
   lazy val urn = "XATRUST12345678"
 
   def emptyUserAnswersForUtr: UserAnswers = models.UserAnswers(userInternalId, utr)
-  def emptyUserAnswersForUrn: UserAnswers = models.UserAnswers(userInternalId, urn, is5mldEnabled = true, isUnderlyingData5mld = true)
+  def emptyUserAnswersForUrn: UserAnswers = models.UserAnswers(userInternalId, urn, is5mldEnabled = true, isUnderlyingData5mld = true, isUnderlyingDataTaxable = false)
 }

--- a/test/utils/TestUserAnswers.scala
+++ b/test/utils/TestUserAnswers.scala
@@ -16,6 +16,7 @@
 
 package utils
 
+import models.UserAnswers
 import org.scalatest.TryValues
 
 object TestUserAnswers extends TryValues {
@@ -25,6 +26,6 @@ object TestUserAnswers extends TryValues {
   lazy val utr = "1234567890"
   lazy val urn = "XATRUST12345678"
 
-  def emptyUserAnswersForUtr = models.UserAnswers(userInternalId, utr)
-  def emptyUserAnswersForUrn = models.UserAnswers(userInternalId, urn, isTrustTaxable = false)
+  def emptyUserAnswersForUtr: UserAnswers = models.UserAnswers(userInternalId, utr)
+  def emptyUserAnswersForUrn: UserAnswers = models.UserAnswers(userInternalId, urn, is5mldEnabled = true, isUnderlyingData5mld = true)
 }


### PR DESCRIPTION
- Determining taxability using untransformed trust details and selection on WhatIsNextPage (4 taxability case objects to give more granular representation of the status of the trust)
- Adding call to backend to determine whether underlying data is 5MLD or not (reliance on value in ExpressTrustYesNoPage seems flakey)
- Fixed an incorrect error message
- General bit of tidy-up in TrustConnector and some response models