### PR TITLE
Reset tasks when removing transforms

### DIFF
--- a/app/controllers/transition/BeforeYouContinueToTaxableController.scala
+++ b/app/controllers/transition/BeforeYouContinueToTaxableController.scala
@@ -26,12 +26,11 @@ import views.html.transition.BeforeYouContinueToTaxableView
 
 @Singleton
 class BeforeYouContinueToTaxableController @Inject()(
-                                               override val messagesApi: MessagesApi,
-                                               actions: Actions,
-                                               val controllerComponents: MessagesControllerComponents,
-                                               view: BeforeYouContinueToTaxableView
-                                             )
-  extends FrontendBaseController with I18nSupport with Logging {
+                                                      override val messagesApi: MessagesApi,
+                                                      actions: Actions,
+                                                      val controllerComponents: MessagesControllerComponents,
+                                                      view: BeforeYouContinueToTaxableView
+                                                    ) extends FrontendBaseController with I18nSupport with Logging {
 
   def onPageLoad(): Action[AnyContent] = actions.verifiedForIdentifier {
     implicit request =>

--- a/app/controllers/transition/ExpressTrustYesNoController.scala
+++ b/app/controllers/transition/ExpressTrustYesNoController.scala
@@ -29,6 +29,7 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.PlaybackRepository
 import services.MaintainATrustService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import utils.Session
 import views.html.transition.ExpressTrustYesNoView
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -87,11 +88,12 @@ class ExpressTrustYesNoController @Inject()(
 
   private def removeTransformsIfNotMigrating(isTrustMigrating: Boolean)
                                             (implicit request: DataRequest[AnyContent]): Future[Unit] = {
-
-    logger.debug("Removing transforms in case user redirected here from RefreshedDataPreSubmitRetrievalAction.")
     if (isTrustMigrating) {
+      logger.info(s"[Session ID: ${Session.id(hc)}] Migrating from non-taxable to taxable. Keeping transforms.")
       Future.successful(())
     } else {
+      logger.info(s"[Session ID: ${Session.id(hc)}] Redirected from RefreshedDataPreSubmitRetrievalAction or " +
+        s"transitioning from 4MLD to 5MLD. Removing transforms and resetting tasks.")
       maintainATrustService.removeTransformsAndResetTaskList(request.userAnswers.identifier)
     }
   }

--- a/app/controllers/transition/NeedToPayTaxYesNoController.scala
+++ b/app/controllers/transition/NeedToPayTaxYesNoController.scala
@@ -27,6 +27,7 @@ import play.api.data.Form
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.PlaybackRepository
+import services.MaintainATrustService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.transition.NeedToPayTaxYesNoView
 
@@ -41,7 +42,8 @@ class NeedToPayTaxYesNoController @Inject()(
                                              val controllerComponents: MessagesControllerComponents,
                                              yesNoFormProvider: YesNoFormProvider,
                                              view: NeedToPayTaxYesNoView,
-                                             trustConnector: TrustConnector
+                                             trustConnector: TrustConnector,
+                                             maintainATrustService: MaintainATrustService
                                      )(implicit ec: ExecutionContext)
   extends FrontendBaseController with I18nSupport with Logging {
 
@@ -96,7 +98,7 @@ class NeedToPayTaxYesNoController @Inject()(
           _ <- trustConnector.setTaxableTrust(request.userAnswers.identifier, needsToPayTax)
           _ <- trustConnector.setTaxableMigrationFlag(request.userAnswers.identifier, needsToPayTax)
         } yield ()
-      case (true, false) => trustConnector.removeTransforms(request.userAnswers.identifier).map(_ => ())
+      case (true, false) => maintainATrustService.removeTransformsAndResetTaskList(request.userAnswers.identifier)
     }
 
   }

--- a/app/controllers/transition/NeedToPayTaxYesNoController.scala
+++ b/app/controllers/transition/NeedToPayTaxYesNoController.scala
@@ -44,7 +44,7 @@ class NeedToPayTaxYesNoController @Inject()(
                                              view: NeedToPayTaxYesNoView,
                                              trustConnector: TrustConnector,
                                              maintainATrustService: MaintainATrustService
-                                     )(implicit ec: ExecutionContext)
+                                           )(implicit ec: ExecutionContext)
   extends FrontendBaseController with I18nSupport with Logging {
 
   private val form: Form[Boolean] = yesNoFormProvider.withPrefix("needToPayTaxYesNo")
@@ -90,12 +90,11 @@ class NeedToPayTaxYesNoController @Inject()(
 
   private def updateTransforms(hasAnswerChanged: Boolean, needsToPayTax: Boolean)
                               (implicit request: DataRequest[AnyContent]): Future[Unit] = {
-
     (hasAnswerChanged, needsToPayTax) match {
       case (false, _) => Future.successful(())
       case (true, true) => trustConnector.setTaxableTrust(request.userAnswers.identifier, needsToPayTax).map(_ => ())
       case (true, false) => maintainATrustService.removeTransformsAndResetTaskList(request.userAnswers.identifier)
     }
-
   }
+
 }

--- a/app/controllers/transition/NeedToPayTaxYesNoController.scala
+++ b/app/controllers/transition/NeedToPayTaxYesNoController.scala
@@ -93,11 +93,7 @@ class NeedToPayTaxYesNoController @Inject()(
 
     (hasAnswerChanged, needsToPayTax) match {
       case (false, _) => Future.successful(())
-      case (true, true) =>
-        for {
-          _ <- trustConnector.setTaxableTrust(request.userAnswers.identifier, needsToPayTax)
-          _ <- trustConnector.setTaxableMigrationFlag(request.userAnswers.identifier, needsToPayTax)
-        } yield ()
+      case (true, true) => trustConnector.setTaxableTrust(request.userAnswers.identifier, needsToPayTax).map(_ => ())
       case (true, false) => maintainATrustService.removeTransformsAndResetTaskList(request.userAnswers.identifier)
     }
 

--- a/app/services/MaintainATrustService.scala
+++ b/app/services/MaintainATrustService.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import connectors.{TrustConnector, TrustsStoreConnector}
+import uk.gov.hmrc.http.HeaderCarrier
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class MaintainATrustService @Inject()(trustsConnector: TrustConnector,
+                                      trustsStoreConnector: TrustsStoreConnector) {
+
+  def removeTransformsAndResetTaskList(identifier: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Unit] = {
+    for {
+      _ <- trustsConnector.removeTransforms(identifier)
+      _ <- trustsStoreConnector.resetTasks(identifier)
+    } yield ()
+  }
+}

--- a/test/controllers/WhatIsNextControllerSpec.scala
+++ b/test/controllers/WhatIsNextControllerSpec.scala
@@ -17,12 +17,13 @@
 package controllers
 
 import base.SpecBase
+import connectors.TrustConnector
 import forms.WhatIsNextFormProvider
 import generators.ModelGenerators
 import models.Underlying4mldTrustIn4mldMode
 import models.pages.WhatIsNext
 import models.pages.WhatIsNext._
-import org.mockito.Matchers.any
+import org.mockito.Matchers.{any, eq => eqTo}
 import org.mockito.Mockito.{never, reset, verify, when}
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalatestplus.mockito.MockitoSugar
@@ -35,6 +36,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.MaintainATrustService
 import uk.gov.hmrc.auth.core.AffinityGroup
+import uk.gov.hmrc.http.HttpResponse
 import views.html.WhatIsNextView
 
 import scala.concurrent.Future
@@ -47,10 +49,15 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
 
   lazy val onSubmit: Call = routes.WhatIsNextController.onSubmit()
   
+  val mockTrustsConnector: TrustConnector = mock[TrustConnector]
   val mockMaintainATrustService: MaintainATrustService = mock[MaintainATrustService]
 
   def beforeTest(): Unit = {
+    reset(mockTrustsConnector)
     reset(mockMaintainATrustService)
+
+    when(mockTrustsConnector.setTaxableMigrationFlag(any(), any())(any(), any()))
+      .thenReturn(Future.successful(HttpResponse(OK, "")))
 
     when(mockMaintainATrustService.removeTransformsAndResetTaskList(any())(any(), any()))
       .thenReturn(Future.successful(()))
@@ -126,6 +133,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
             val userAnswers = emptyUserAnswersForUtr
 
             val application = applicationBuilder(userAnswers = Some(userAnswers), AffinityGroup.Agent)
+              .overrides(bind[TrustConnector].toInstance(mockTrustsConnector))
               .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
               .build()
 
@@ -151,6 +159,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
             val userAnswers = emptyUserAnswersForUtr
 
             val application = applicationBuilder(userAnswers = Some(userAnswers))
+              .overrides(bind[TrustConnector].toInstance(mockTrustsConnector))
               .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
               .build()
 
@@ -179,6 +188,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
             val userAnswers = emptyUserAnswersForUtr
 
             val application = applicationBuilder(userAnswers = Some(userAnswers))
+              .overrides(bind[TrustConnector].toInstance(mockTrustsConnector))
               .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
               .build()
 
@@ -205,6 +215,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
               val userAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = false)
 
               val application = applicationBuilder(userAnswers = Some(userAnswers))
+                .overrides(bind[TrustConnector].toInstance(mockTrustsConnector))
                 .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
                 .build()
 
@@ -231,6 +242,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
                 val userAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
                 val application = applicationBuilder(userAnswers = Some(userAnswers))
+                  .overrides(bind[TrustConnector].toInstance(mockTrustsConnector))
                   .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
                   .build()
 
@@ -253,6 +265,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
                 val userAnswers = emptyUserAnswersForUrn
 
                 val application = applicationBuilder(userAnswers = Some(userAnswers))
+                  .overrides(bind[TrustConnector].toInstance(mockTrustsConnector))
                   .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
                   .build()
 
@@ -286,6 +299,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
                 .set(WhatIsNextPage, previousAnswer).success.value
 
               val application = applicationBuilder(userAnswers = Some(userAnswers))
+                .overrides(bind[TrustConnector].toInstance(mockTrustsConnector))
                 .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
                 .build()
 
@@ -315,6 +329,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
                 .set(WhatIsNextPage, previousAnswer).success.value
 
               val application = applicationBuilder(userAnswers = Some(userAnswers))
+                .overrides(bind[TrustConnector].toInstance(mockTrustsConnector))
                 .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
                 .build()
 
@@ -341,6 +356,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
           val userAnswers = emptyUserAnswersForUtr
 
           val application = applicationBuilder(userAnswers = Some(userAnswers))
+            .overrides(bind[TrustConnector].toInstance(mockTrustsConnector))
             .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
             .build()
 
@@ -365,6 +381,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
           val userAnswers = emptyUserAnswersForUtr
 
           val application = applicationBuilder(userAnswers = Some(userAnswers))
+            .overrides(bind[TrustConnector].toInstance(mockTrustsConnector))
             .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
             .build()
 
@@ -389,6 +406,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
           val userAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true)
 
           val application = applicationBuilder(userAnswers = Some(userAnswers))
+            .overrides(bind[TrustConnector].toInstance(mockTrustsConnector))
             .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
             .build()
 
@@ -416,6 +434,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
           beforeTest()
 
           val application = applicationBuilder(userAnswers = Some(emptyUserAnswersForUtr))
+            .overrides(bind[TrustConnector].toInstance(mockTrustsConnector))
             .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
             .build()
 
@@ -445,6 +464,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
               .set(WhatIsNextPage, previousAnswer).success.value
 
             val application = applicationBuilder(userAnswers = Some(userAnswers))
+              .overrides(bind[TrustConnector].toInstance(mockTrustsConnector))
               .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
               .build()
 
@@ -476,6 +496,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
             .set(WhatIsNextPage, previousAnswer).success.value
 
           val application = applicationBuilder(userAnswers = Some(userAnswers))
+            .overrides(bind[TrustConnector].toInstance(mockTrustsConnector))
             .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
             .build()
 
@@ -497,6 +518,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
         beforeTest()
 
         val application = applicationBuilder(userAnswers = Some(emptyUserAnswersForUtr))
+          .overrides(bind[TrustConnector].toInstance(mockTrustsConnector))
           .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
           .build()
 
@@ -536,4 +558,51 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
       application.stop()
     }
   }
+
+  "set taxable migration flag to true when NeedsToPayTax selected" in {
+
+    beforeTest()
+
+    val application = applicationBuilder(userAnswers = Some(emptyUserAnswersForUtr))
+      .overrides(bind[TrustConnector].toInstance(mockTrustsConnector))
+      .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
+      .build()
+
+    implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] = FakeRequest(POST, onSubmit.url)
+      .withFormUrlEncodedBody(("value", NeedsToPayTax.toString))
+
+    val result = route(application, request).value
+
+    status(result) mustEqual SEE_OTHER
+
+    verify(mockTrustsConnector).setTaxableMigrationFlag(any(), eqTo(true))(any(), any())
+
+    application.stop()
+  }
+
+  "set taxable migration flag to false when new answer is neither NeedsToPayTax nor GeneratePdf" in {
+
+    val gen = arbitrary[WhatIsNext]
+
+    forAll(gen.suchThat(x => x != NeedsToPayTax && x != GeneratePdf)) { answer =>
+      beforeTest()
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswersForUtr))
+        .overrides(bind[TrustConnector].toInstance(mockTrustsConnector))
+        .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
+        .build()
+
+      implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] = FakeRequest(POST, onSubmit.url)
+        .withFormUrlEncodedBody(("value", answer.toString))
+
+      val result = route(application, request).value
+
+      status(result) mustEqual SEE_OTHER
+
+      verify(mockTrustsConnector).setTaxableMigrationFlag(any(), eqTo(false))(any(), any())
+
+      application.stop()
+    }
+  }
+
 }

--- a/test/controllers/WhatIsNextControllerSpec.scala
+++ b/test/controllers/WhatIsNextControllerSpec.scala
@@ -17,7 +17,6 @@
 package controllers
 
 import base.SpecBase
-import connectors.TrustConnector
 import forms.WhatIsNextFormProvider
 import generators.ModelGenerators
 import models.Underlying4mldTrustIn4mldMode
@@ -34,6 +33,7 @@ import play.api.inject.bind
 import play.api.mvc.{AnyContentAsFormUrlEncoded, Call}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import services.MaintainATrustService
 import uk.gov.hmrc.auth.core.AffinityGroup
 import views.html.WhatIsNextView
 
@@ -46,14 +46,14 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
   lazy val onPageLoad: String = routes.WhatIsNextController.onPageLoad().url
 
   lazy val onSubmit: Call = routes.WhatIsNextController.onSubmit()
-
-  val mockTrustConnector: TrustConnector = mock[TrustConnector]
+  
+  val mockMaintainATrustService: MaintainATrustService = mock[MaintainATrustService]
 
   def beforeTest(): Unit = {
-    reset(mockTrustConnector)
+    reset(mockMaintainATrustService)
 
-    when(mockTrustConnector.removeTransforms(any())(any(), any()))
-      .thenReturn(Future.successful(okResponse))
+    when(mockMaintainATrustService.removeTransformsAndResetTaskList(any())(any(), any()))
+      .thenReturn(Future.successful(()))
   }
 
   "WhatIsNext Controller" must {
@@ -126,7 +126,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
             val userAnswers = emptyUserAnswersForUtr
 
             val application = applicationBuilder(userAnswers = Some(userAnswers), AffinityGroup.Agent)
-              .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
+              .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
               .build()
 
             implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] = FakeRequest(POST, onSubmit.url)
@@ -151,7 +151,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
             val userAnswers = emptyUserAnswersForUtr
 
             val application = applicationBuilder(userAnswers = Some(userAnswers))
-              .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
+              .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
               .build()
 
             implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] = FakeRequest(POST, onSubmit.url)
@@ -179,7 +179,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
             val userAnswers = emptyUserAnswersForUtr
 
             val application = applicationBuilder(userAnswers = Some(userAnswers))
-              .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
+              .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
               .build()
 
             implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] = FakeRequest(POST, onSubmit.url)
@@ -205,7 +205,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
               val userAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = false)
 
               val application = applicationBuilder(userAnswers = Some(userAnswers))
-                .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
+                .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
                 .build()
 
               implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] = FakeRequest(POST, onSubmit.url)
@@ -231,7 +231,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
                 val userAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true, isUnderlyingData5mld = true)
 
                 val application = applicationBuilder(userAnswers = Some(userAnswers))
-                  .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
+                  .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
                   .build()
 
                 implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] = FakeRequest(POST, onSubmit.url)
@@ -253,7 +253,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
                 val userAnswers = emptyUserAnswersForUrn
 
                 val application = applicationBuilder(userAnswers = Some(userAnswers))
-                  .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
+                  .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
                   .build()
 
                 implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] = FakeRequest(POST, onSubmit.url)
@@ -286,7 +286,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
                 .set(WhatIsNextPage, previousAnswer).success.value
 
               val application = applicationBuilder(userAnswers = Some(userAnswers))
-                .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
+                .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
                 .build()
 
               implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] = FakeRequest(POST, onSubmit.url)
@@ -315,7 +315,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
                 .set(WhatIsNextPage, previousAnswer).success.value
 
               val application = applicationBuilder(userAnswers = Some(userAnswers))
-                .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
+                .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
                 .build()
 
               implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] = FakeRequest(POST, onSubmit.url)
@@ -341,7 +341,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
           val userAnswers = emptyUserAnswersForUtr
 
           val application = applicationBuilder(userAnswers = Some(userAnswers))
-            .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
+            .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
             .build()
 
           implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] = FakeRequest(POST, onSubmit.url)
@@ -365,7 +365,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
           val userAnswers = emptyUserAnswersForUtr
 
           val application = applicationBuilder(userAnswers = Some(userAnswers))
-            .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
+            .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
             .build()
 
           implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] = FakeRequest(POST, onSubmit.url)
@@ -389,7 +389,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
           val userAnswers = emptyUserAnswersForUtr.copy(is5mldEnabled = true)
 
           val application = applicationBuilder(userAnswers = Some(userAnswers))
-            .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
+            .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
             .build()
 
           implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] = FakeRequest(POST, onSubmit.url)
@@ -416,7 +416,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
           beforeTest()
 
           val application = applicationBuilder(userAnswers = Some(emptyUserAnswersForUtr))
-            .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
+            .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
             .build()
 
           implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] = FakeRequest(POST, onSubmit.url)
@@ -426,7 +426,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
 
           status(result) mustEqual SEE_OTHER
 
-          verify(mockTrustConnector).removeTransforms(any())(any(), any())
+          verify(mockMaintainATrustService).removeTransformsAndResetTaskList(any())(any(), any())
 
           application.stop()
         }
@@ -445,7 +445,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
               .set(WhatIsNextPage, previousAnswer).success.value
 
             val application = applicationBuilder(userAnswers = Some(userAnswers))
-              .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
+              .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
               .build()
 
             implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] = FakeRequest(POST, onSubmit.url)
@@ -455,7 +455,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
 
             status(result) mustEqual SEE_OTHER
 
-            verify(mockTrustConnector).removeTransforms(any())(any(), any())
+            verify(mockMaintainATrustService).removeTransformsAndResetTaskList(any())(any(), any())
 
             application.stop()
           }
@@ -476,7 +476,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
             .set(WhatIsNextPage, previousAnswer).success.value
 
           val application = applicationBuilder(userAnswers = Some(userAnswers))
-            .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
+            .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
             .build()
 
           implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] = FakeRequest(POST, onSubmit.url)
@@ -486,7 +486,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
 
           status(result) mustEqual SEE_OTHER
 
-          verify(mockTrustConnector, never()).removeTransforms(any())(any(), any())
+          verify(mockMaintainATrustService, never()).removeTransformsAndResetTaskList(any())(any(), any())
 
           application.stop()
         }
@@ -497,7 +497,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
         beforeTest()
 
         val application = applicationBuilder(userAnswers = Some(emptyUserAnswersForUtr))
-          .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
+          .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
           .build()
 
         implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] = FakeRequest(POST, onSubmit.url)
@@ -507,29 +507,7 @@ class WhatIsNextControllerSpec extends SpecBase with MockitoSugar with ScalaChec
 
         status(result) mustEqual SEE_OTHER
 
-        verify(mockTrustConnector, never()).removeTransforms(any())(any(), any())
-
-        application.stop()
-      }
-    }
-
-    "not set taxable migration flag" when {
-      "GeneratePdf selected" in {
-
-        beforeTest()
-
-        val application = applicationBuilder(userAnswers = Some(emptyUserAnswersForUrn))
-          .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
-          .build()
-
-        implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] = FakeRequest(POST, onSubmit.url)
-          .withFormUrlEncodedBody(("value", GeneratePdf.toString))
-
-        val result = route(application, request).value
-
-        status(result) mustEqual SEE_OTHER
-
-        verify(mockTrustConnector, never()).setTaxableMigrationFlag(any(), any())(any(), any())
+        verify(mockMaintainATrustService, never()).removeTransformsAndResetTaskList(any())(any(), any())
 
         application.stop()
       }

--- a/test/controllers/transition/ExpressTrustYesNoControllerSpec.scala
+++ b/test/controllers/transition/ExpressTrustYesNoControllerSpec.scala
@@ -30,6 +30,7 @@ import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import repositories.PlaybackRepository
+import services.MaintainATrustService
 import views.html.transition.ExpressTrustYesNoView
 
 import scala.concurrent.Future
@@ -86,18 +87,20 @@ class ExpressTrustYesNoControllerSpec extends SpecBase with MockitoSugar {
 
       val mockPlaybackRepository = mock[PlaybackRepository]
       val mockTrustsConnector = mock[TrustConnector]
+      val mockMaintainATrustService = mock[MaintainATrustService]
 
       when(mockPlaybackRepository.set(any()))
         .thenReturn(Future.successful(true))
 
-      when(mockTrustsConnector.removeTransforms(any())(any(), any()))
-        .thenReturn(Future.successful(okResponse))
+      when(mockMaintainATrustService.removeTransformsAndResetTaskList(any())(any(), any()))
+        .thenReturn(Future.successful(()))
 
       when(mockTrustsConnector.setExpressTrust(any(), any())(any(), any()))
         .thenReturn(Future.successful(okResponse))
 
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswersForUtr))
         .overrides(bind[TrustConnector].toInstance(mockTrustsConnector))
+        .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
         .build()
 
       val request = FakeRequest(POST, expressTrustYesNoRoute)
@@ -109,7 +112,7 @@ class ExpressTrustYesNoControllerSpec extends SpecBase with MockitoSugar {
 
       redirectLocation(result).value mustEqual routes.ConfirmTrustTaxableController.onPageLoad().url
 
-      verify(mockTrustsConnector).removeTransforms(any())(any(), any())
+      verify(mockMaintainATrustService).removeTransformsAndResetTaskList(any())(any(), any())
       verify(mockTrustsConnector).setExpressTrust(any(), eqTo(validAnswer))(any(), any())
 
       application.stop()
@@ -119,19 +122,20 @@ class ExpressTrustYesNoControllerSpec extends SpecBase with MockitoSugar {
 
       val mockPlaybackRepository = mock[PlaybackRepository]
       val mockTrustsConnector = mock[TrustConnector]
+      val mockMaintainATrustService = mock[MaintainATrustService]
 
       when(mockPlaybackRepository.set(any()))
         .thenReturn(Future.successful(true))
 
-      when(mockTrustsConnector.removeTransforms(any())(any(), any()))
-        .thenReturn(Future.successful(okResponse))
+      when(mockMaintainATrustService.removeTransformsAndResetTaskList(any())(any(), any()))
+        .thenReturn(Future.successful(()))
 
       when(mockTrustsConnector.setExpressTrust(any(), any())(any(), any()))
         .thenReturn(Future.successful(okResponse))
 
-      val application = applicationBuilder(userAnswers = Some(
-        emptyUserAnswersForUtr.set(WhatIsNextPage, NeedsToPayTax).success.value
-      )).overrides(bind[TrustConnector].toInstance(mockTrustsConnector))
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswersForUtr.set(WhatIsNextPage, NeedsToPayTax).success.value))
+        .overrides(bind[TrustConnector].toInstance(mockTrustsConnector))
+        .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
         .build()
 
       val request = FakeRequest(POST, expressTrustYesNoRoute)
@@ -143,7 +147,7 @@ class ExpressTrustYesNoControllerSpec extends SpecBase with MockitoSugar {
 
       redirectLocation(result).value mustEqual controllers.tasklist.routes.TaskListController.onPageLoad().url
 
-      verify(mockTrustsConnector, times(0)).removeTransforms(any())(any(), any())
+      verify(mockMaintainATrustService, times(0)).removeTransformsAndResetTaskList(any())(any(), any())
       verify(mockTrustsConnector).setExpressTrust(any(), eqTo(validAnswer))(any(), any())
 
       application.stop()

--- a/test/controllers/transition/NeedToPayTaxYesNoControllerSpec.scala
+++ b/test/controllers/transition/NeedToPayTaxYesNoControllerSpec.scala
@@ -29,6 +29,7 @@ import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import repositories.PlaybackRepository
+import services.MaintainATrustService
 import utils.TestUserAnswers.utr
 import views.html.transition.NeedToPayTaxYesNoView
 
@@ -85,12 +86,13 @@ class NeedToPayTaxYesNoControllerSpec extends SpecBase with MockitoSugar {
 
       val mockPlaybackRepository = mock[PlaybackRepository]
       val mockTrustConnector = mock[TrustConnector]
+      val mockMaintainATrustService = mock[MaintainATrustService]
 
       when(mockPlaybackRepository.set(any()))
         .thenReturn(Future.successful(true))
 
-      when(mockTrustConnector.removeTransforms(any())(any(), any()))
-        .thenReturn(Future.successful(okResponse))
+      when(mockMaintainATrustService.removeTransformsAndResetTaskList(any())(any(), any()))
+        .thenReturn(Future.successful(()))
 
       when(mockTrustConnector.setTaxableTrust(any(), any())(any(), any()))
         .thenReturn(Future.successful(okResponse))
@@ -100,6 +102,7 @@ class NeedToPayTaxYesNoControllerSpec extends SpecBase with MockitoSugar {
 
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswersForUtr))
         .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
+        .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
         .build()
 
       val request = FakeRequest(POST, needToPayTaxYesNoRoute)
@@ -111,7 +114,7 @@ class NeedToPayTaxYesNoControllerSpec extends SpecBase with MockitoSugar {
 
       redirectLocation(result).value mustEqual routes.BeforeYouContinueToTaxableController.onPageLoad().url
 
-      verify(mockTrustConnector, times(0)).removeTransforms(any())(any(), any())
+      verify(mockMaintainATrustService, times(0)).removeTransformsAndResetTaskList(any())(any(), any())
       verify(mockTrustConnector).setTaxableMigrationFlag(any(), eqTo(true))(any(), any())
       verify(mockTrustConnector).setTaxableTrust(any(), eqTo(true))(any(), any())
 
@@ -122,12 +125,13 @@ class NeedToPayTaxYesNoControllerSpec extends SpecBase with MockitoSugar {
 
       val mockPlaybackRepository = mock[PlaybackRepository]
       val mockTrustConnector = mock[TrustConnector]
+      val mockMaintainATrustService = mock[MaintainATrustService]
 
       when(mockPlaybackRepository.set(any()))
         .thenReturn(Future.successful(true))
 
-      when(mockTrustConnector.removeTransforms(any())(any(), any()))
-        .thenReturn(Future.successful(okResponse))
+      when(mockMaintainATrustService.removeTransformsAndResetTaskList(any())(any(), any()))
+        .thenReturn(Future.successful(()))
 
       when(mockTrustConnector.setTaxableTrust(any(), any())(any(), any()))
         .thenReturn(Future.successful(okResponse))
@@ -140,6 +144,7 @@ class NeedToPayTaxYesNoControllerSpec extends SpecBase with MockitoSugar {
 
       val application = applicationBuilder(userAnswers = Some(userAnswers))
         .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
+        .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
         .build()
 
       val request = FakeRequest(POST, needToPayTaxYesNoRoute)
@@ -151,7 +156,7 @@ class NeedToPayTaxYesNoControllerSpec extends SpecBase with MockitoSugar {
 
       redirectLocation(result).value mustEqual routes.BeforeYouContinueToTaxableController.onPageLoad().url
 
-      verify(mockTrustConnector, times(0)).removeTransforms(any())(any(), any())
+      verify(mockMaintainATrustService, times(0)).removeTransformsAndResetTaskList(any())(any(), any())
       verify(mockTrustConnector).setTaxableMigrationFlag(any(), eqTo(true))(any(), any())
       verify(mockTrustConnector).setTaxableTrust(any(), eqTo(true))(any(), any())
 
@@ -162,12 +167,13 @@ class NeedToPayTaxYesNoControllerSpec extends SpecBase with MockitoSugar {
 
       val mockPlaybackRepository = mock[PlaybackRepository]
       val mockTrustConnector = mock[TrustConnector]
+      val mockMaintainATrustService = mock[MaintainATrustService]
 
       when(mockPlaybackRepository.set(any()))
         .thenReturn(Future.successful(true))
 
-      when(mockTrustConnector.removeTransforms(any())(any(), any()))
-        .thenReturn(Future.successful(okResponse))
+      when(mockMaintainATrustService.removeTransformsAndResetTaskList(any())(any(), any()))
+        .thenReturn(Future.successful(()))
 
       when(mockTrustConnector.setTaxableTrust(any(), any())(any(), any()))
         .thenReturn(Future.successful(okResponse))
@@ -180,6 +186,7 @@ class NeedToPayTaxYesNoControllerSpec extends SpecBase with MockitoSugar {
 
       val application = applicationBuilder(userAnswers = Some(userAnswers))
         .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
+        .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
         .build()
 
       val request = FakeRequest(POST, needToPayTaxYesNoRoute)
@@ -191,7 +198,7 @@ class NeedToPayTaxYesNoControllerSpec extends SpecBase with MockitoSugar {
 
       redirectLocation(result).value mustEqual routes.BeforeYouContinueToTaxableController.onPageLoad().url
 
-      verify(mockTrustConnector, times(0)).removeTransforms(any())(any(), any())
+      verify(mockMaintainATrustService, times(0)).removeTransformsAndResetTaskList(any())(any(), any())
       verify(mockTrustConnector, times(0)).setTaxableMigrationFlag(any(), eqTo(true))(any(), any())
       verify(mockTrustConnector, times(0)).setTaxableTrust(any(), eqTo(true))(any(), any())
 
@@ -202,12 +209,13 @@ class NeedToPayTaxYesNoControllerSpec extends SpecBase with MockitoSugar {
 
       val mockPlaybackRepository = mock[PlaybackRepository]
       val mockTrustConnector = mock[TrustConnector]
+      val mockMaintainATrustService = mock[MaintainATrustService]
 
       when(mockPlaybackRepository.set(any()))
         .thenReturn(Future.successful(true))
 
-      when(mockTrustConnector.removeTransforms(any())(any(), any()))
-        .thenReturn(Future.successful(okResponse))
+      when(mockMaintainATrustService.removeTransformsAndResetTaskList(any())(any(), any()))
+        .thenReturn(Future.successful(()))
 
       when(mockTrustConnector.setTaxableTrust(any(), any())(any(), any()))
         .thenReturn(Future.successful(okResponse))
@@ -217,6 +225,7 @@ class NeedToPayTaxYesNoControllerSpec extends SpecBase with MockitoSugar {
 
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswersForUtr))
         .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
+        .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
         .build()
 
       val request = FakeRequest(POST, needToPayTaxYesNoRoute)
@@ -228,7 +237,7 @@ class NeedToPayTaxYesNoControllerSpec extends SpecBase with MockitoSugar {
 
       redirectLocation(result).value mustEqual controllers.routes.WhatIsNextController.onPageLoad().url
 
-      verify(mockTrustConnector).removeTransforms(any())(any(), any())
+      verify(mockMaintainATrustService).removeTransformsAndResetTaskList(any())(any(), any())
       verify(mockTrustConnector, times(0)).setTaxableMigrationFlag(any(), any())(any(), any())
       verify(mockTrustConnector, times(0)).setTaxableTrust(any(), any())(any(), any())
 

--- a/test/controllers/transition/NeedToPayTaxYesNoControllerSpec.scala
+++ b/test/controllers/transition/NeedToPayTaxYesNoControllerSpec.scala
@@ -97,9 +97,6 @@ class NeedToPayTaxYesNoControllerSpec extends SpecBase with MockitoSugar {
       when(mockTrustConnector.setTaxableTrust(any(), any())(any(), any()))
         .thenReturn(Future.successful(okResponse))
 
-      when(mockTrustConnector.setTaxableMigrationFlag(any(), any())(any(), any()))
-        .thenReturn(Future.successful(okResponse))
-
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswersForUtr))
         .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
         .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
@@ -115,7 +112,6 @@ class NeedToPayTaxYesNoControllerSpec extends SpecBase with MockitoSugar {
       redirectLocation(result).value mustEqual routes.BeforeYouContinueToTaxableController.onPageLoad().url
 
       verify(mockMaintainATrustService, times(0)).removeTransformsAndResetTaskList(any())(any(), any())
-      verify(mockTrustConnector).setTaxableMigrationFlag(any(), eqTo(true))(any(), any())
       verify(mockTrustConnector).setTaxableTrust(any(), eqTo(true))(any(), any())
 
       application.stop()
@@ -136,9 +132,6 @@ class NeedToPayTaxYesNoControllerSpec extends SpecBase with MockitoSugar {
       when(mockTrustConnector.setTaxableTrust(any(), any())(any(), any()))
         .thenReturn(Future.successful(okResponse))
 
-      when(mockTrustConnector.setTaxableMigrationFlag(any(), any())(any(), any()))
-        .thenReturn(Future.successful(okResponse))
-
       val userAnswers = emptyUserAnswersForUtr
         .set(NeedToPayTaxYesNoPage, false).success.value
 
@@ -157,7 +150,6 @@ class NeedToPayTaxYesNoControllerSpec extends SpecBase with MockitoSugar {
       redirectLocation(result).value mustEqual routes.BeforeYouContinueToTaxableController.onPageLoad().url
 
       verify(mockMaintainATrustService, times(0)).removeTransformsAndResetTaskList(any())(any(), any())
-      verify(mockTrustConnector).setTaxableMigrationFlag(any(), eqTo(true))(any(), any())
       verify(mockTrustConnector).setTaxableTrust(any(), eqTo(true))(any(), any())
 
       application.stop()
@@ -178,9 +170,6 @@ class NeedToPayTaxYesNoControllerSpec extends SpecBase with MockitoSugar {
       when(mockTrustConnector.setTaxableTrust(any(), any())(any(), any()))
         .thenReturn(Future.successful(okResponse))
 
-      when(mockTrustConnector.setTaxableMigrationFlag(any(), any())(any(), any()))
-        .thenReturn(Future.successful(okResponse))
-
       val userAnswers = emptyUserAnswersForUtr
         .set(NeedToPayTaxYesNoPage, true).success.value
 
@@ -199,7 +188,6 @@ class NeedToPayTaxYesNoControllerSpec extends SpecBase with MockitoSugar {
       redirectLocation(result).value mustEqual routes.BeforeYouContinueToTaxableController.onPageLoad().url
 
       verify(mockMaintainATrustService, times(0)).removeTransformsAndResetTaskList(any())(any(), any())
-      verify(mockTrustConnector, times(0)).setTaxableMigrationFlag(any(), eqTo(true))(any(), any())
       verify(mockTrustConnector, times(0)).setTaxableTrust(any(), eqTo(true))(any(), any())
 
       application.stop()
@@ -220,9 +208,6 @@ class NeedToPayTaxYesNoControllerSpec extends SpecBase with MockitoSugar {
       when(mockTrustConnector.setTaxableTrust(any(), any())(any(), any()))
         .thenReturn(Future.successful(okResponse))
 
-      when(mockTrustConnector.setTaxableMigrationFlag(any(), any())(any(), any()))
-        .thenReturn(Future.successful(okResponse))
-
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswersForUtr))
         .overrides(bind[TrustConnector].toInstance(mockTrustConnector))
         .overrides(bind[MaintainATrustService].toInstance(mockMaintainATrustService))
@@ -238,7 +223,6 @@ class NeedToPayTaxYesNoControllerSpec extends SpecBase with MockitoSugar {
       redirectLocation(result).value mustEqual controllers.routes.WhatIsNextController.onPageLoad().url
 
       verify(mockMaintainATrustService).removeTransformsAndResetTaskList(any())(any(), any())
-      verify(mockTrustConnector, times(0)).setTaxableMigrationFlag(any(), any())(any(), any())
       verify(mockTrustConnector, times(0)).setTaxableTrust(any(), any())(any(), any())
 
       application.stop()

--- a/test/services/MaintainATrustServiceSpec.scala
+++ b/test/services/MaintainATrustServiceSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import base.SpecBase
+import connectors.{TrustConnector, TrustsStoreConnector}
+import controllers.Assets.OK
+import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.Mockito.{verify, when}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
+
+class MaintainATrustServiceSpec extends SpecBase {
+
+  "MaintainATrustService" when {
+
+    ".removeTransformsAndResetTaskList" must {
+      "remove transforms and reset task list" in {
+
+        implicit val hc: HeaderCarrier = HeaderCarrier()
+
+        val identifier = "identifier"
+
+        val mockTrustsConnector = mock[TrustConnector]
+        val mockTrustsStoreConnector = mock[TrustsStoreConnector]
+
+        when(mockTrustsConnector.removeTransforms(any())(any(), any())).thenReturn(Future.successful(HttpResponse(OK, "")))
+        when(mockTrustsStoreConnector.resetTasks(any())(any(), any())).thenReturn(Future.successful(HttpResponse(OK, "")))
+
+        val service = new MaintainATrustService(mockTrustsConnector, mockTrustsStoreConnector)
+
+        Await.result(service.removeTransformsAndResetTaskList(identifier), Duration.Inf)
+
+        verify(mockTrustsConnector).removeTransforms(eqTo(identifier))(any(), any())
+        verify(mockTrustsStoreConnector).resetTasks(eqTo(identifier))(any(), any())
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
- Resetting tasks in conjunction with removing transforms
- Making `setTaxableMigrationFlag` call inside the WhatIsNextController to give greater control over its state