### PR TITLE
ExpressYesNo now respects isMigratingToTaxable flag

### DIFF
--- a/app/controllers/transition/ConfirmTrustTaxableController.scala
+++ b/app/controllers/transition/ConfirmTrustTaxableController.scala
@@ -57,7 +57,10 @@ class ConfirmTrustTaxableController @Inject()(
         updatedAnswers <- Future.fromTry(request.userAnswers.set(WhatIsNextPage, MakeChanges))
         _ <- playbackRepository.set(updatedAnswers)
         _ <- trustsConnector.setTaxableTrust(request.userAnswers.identifier, value = true)
-      } yield Redirect(declarationUrl(request.user.affinityGroup, isTrustMigratingFromNonTaxableToTaxable = true))
+      } yield Redirect(declarationUrl(
+        request.user.affinityGroup,
+        isTrustMigratingFromNonTaxableToTaxable = request.userAnswers.isTrustMigratingFromNonTaxableToTaxable
+      ))
   }
 
 }


### PR DESCRIPTION
- Ensures it respects the isMigratingToTaxable flag and no longer
  assumes in every case they're going from non-tax to tax
- Controller is shared on the 4 to 5MLD journey and non-tax to tax
  journey