### PR TITLE
[DP][DDCE-2950] Restore print functionality

### DIFF
--- a/app/assets/javascripts/print.js
+++ b/app/assets/javascripts/print.js
@@ -1,6 +1,15 @@
 $(document).ready(function() {
 
+    const printButton = document.getElementById("print-button")
+    printButton.addEventListener("click", print)
+
+    // required because using just "window.print()" in the above event listener causes it to fire on page load
+    function print(){
+        window.print()
+    }
+
     function beforePrintCall(){
+        printButton.removeEventListener("click", print)
         if($('.no-details').length > 0){
             // store current focussed element to return focus to later
             var fe = document.activeElement;
@@ -38,6 +47,7 @@ $(document).ready(function() {
         } else {
             $('details').removeAttr("open");
         }
+        printButton.addEventListener("click", print)
     }
 
     //Chrome

--- a/app/views/components/Button.scala.html
+++ b/app/views/components/Button.scala.html
@@ -29,5 +29,5 @@ attributes: Map[String, String] = Map.empty
  isStartButton = isStartButton,
  content = Text(messages(messageKey)),
  classes = if (isPrintButton) "govuk-button--secondary print-hidden" else "",
- attributes = if (isPrintButton) Map("onClick" -> "window.print()", "id" -> "print") else attributes
+ attributes = if (isPrintButton) Map("id" -> "print-button") else attributes
 ))

--- a/app/views/print/PrintLastDeclaredAnswersView.scala.html
+++ b/app/views/print/PrintLastDeclaredAnswersView.scala.html
@@ -17,6 +17,7 @@
 @import viewmodels.AnswerSection
 @import utils.SectionFormatter.formatAnswerSection
 @import views.html.components.{Heading, Button, Warning, ReturnToTop, SubmitButton}
+@import views.html.helper.CSPNonce
 
 @this(
     main_template: MainTemplate,
@@ -35,6 +36,8 @@
     title = messages("playbackAnswers.title"),
     showBackLink = true
     ) {
+
+    <script src='@routes.Assets.versioned("javascripts/print.js")' @{CSPNonce.attr}></script>
 
     @headingComp("playbackAnswers.heading", headingSize = "govuk-heading-xl")
 

--- a/app/views/print/PrintMaintainDeclaredAnswersView.scala.html
+++ b/app/views/print/PrintMaintainDeclaredAnswersView.scala.html
@@ -17,6 +17,7 @@
 @import viewmodels.{AnswerSection, Section}
 @import utils.SectionFormatter.formatAnswerSection
 @import views.html.components.{Heading, Button, SubmitButton, Warning, ReturnToTop}
+@import views.html.helper.CSPNonce
 
 @this(
     main_template: MainTemplate,
@@ -42,6 +43,8 @@
     title = messages("playbackDeclarationAnswers.title"),
     showBackLink = true
     ) {
+
+    <script src='@routes.Assets.versioned("javascripts/print.js")' @{CSPNonce.attr}></script>
 
     @headingComp("playbackDeclarationAnswers.heading", headingSize = "govuk-heading-xl")
 

--- a/app/views/print/PrintMaintainDraftAnswersView.scala.html
+++ b/app/views/print/PrintMaintainDraftAnswersView.scala.html
@@ -17,6 +17,7 @@
 @import viewmodels.AnswerSection
 @import utils.SectionFormatter.formatAnswerSection
 @import views.html.components.{Heading, Button, SubmitButton, ReturnToTop}
+@import views.html.helper.CSPNonce
 
 @this(
     main_template: MainTemplate,
@@ -38,6 +39,8 @@
     title = messages("playbackDraftAnswers.title"),
     showBackLink = true
     ) {
+
+    <script src='@routes.Assets.versioned("javascripts/print.js")' @{CSPNonce.attr}></script>
 
     @headingComp("playbackDraftAnswers.heading", headingSize = "govuk-heading-xl")
 

--- a/app/views/print/PrintMaintainFinalDeclaredAnswersView.scala.html
+++ b/app/views/print/PrintMaintainFinalDeclaredAnswersView.scala.html
@@ -17,6 +17,7 @@
 @import viewmodels.AnswerSection
 @import utils.SectionFormatter.formatAnswerSection
 @import views.html.components.{Heading, Button, ReturnToTop}
+@import views.html.helper.CSPNonce
 
 @this(
     main_template: MainTemplate,
@@ -41,6 +42,8 @@
     title = messages("playbackFinalDeclarationAnswers.title"),
     showBackLink = true
     ) {
+
+    <script src='@routes.Assets.versioned("javascripts/print.js")' @{CSPNonce.attr}></script>
 
     @headingComp("playbackFinalDeclarationAnswers.heading", headingSize = "govuk-heading-xl")
 


### PR DESCRIPTION
Same as [this PR](https://github.com/hmrc/trusts-frontend/pull/848/files) for trusts frontend deployed a week ago.

Manually tested on each of the 4 pages with print functionality, see screenshots
<img width="1792" alt="answers_declaration" src="https://user-images.githubusercontent.com/63240616/162177387-50450715-62cf-4a70-a78a-2e3ae29d5eff.png">
<img width="1792" alt="last_declaration" src="https://user-images.githubusercontent.com/63240616/162177435-0c0475e0-ea72-432f-b2e3-1f0cd5f65c46.png">
<img width="1792" alt="draft_declaration" src="https://user-images.githubusercontent.com/63240616/162177462-413b86a3-d98b-4ca2-b5ed-89f9abea1121.png">
<img width="1792" alt="final_answers_declartion" src="https://user-images.githubusercontent.com/63240616/162177474-178a9dc7-774c-45db-9206-71878cf1d3a2.png">
